### PR TITLE
Port terrain/generator.py to Python 3 (#6)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import ConfigParser
+import configparser
 import random
 import sys
 import time
@@ -10,13 +10,8 @@ import pygame, pygame.locals
 
 from terrain.generator import terrain_generator
 
-if not pygame.font: print 'Warning, fonts disabled'
-
-try:
-    import psyco
-    psyco.full()
-except ImportError:
-    pass
+if not pygame.font:
+    print('Warning, fonts disabled')
 
 
 def get_mind(name):
@@ -59,7 +54,7 @@ SPAWN_TOTAL_ENERGY = BODY_ENERGY + SPAWN_LOST_ENERGY
 
 TIMEOUT = None
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 
 
 def get_next_move(old_x, old_y, x, y):
@@ -104,8 +99,8 @@ class Game(object):
         else:
             self.n_plants = 14
             
-        # Add some randomly placed plants to the map. 
-        for x in xrange(self.n_plants):
+        # Add some randomly placed plants to the map.
+        for x in range(self.n_plants):
             mx = random.randrange(1, self.width - 1)
             my = random.randrange(1, self.height - 1)
             eff = random.randrange(PLANT_MIN_OUTPUT, PLANT_MAX_OUTPUT)
@@ -120,7 +115,7 @@ class Game(object):
 
         # Create an agent for each mind and place on map at a different plant.
         self.agent_map.lock()
-        for idx in xrange(len(self.minds)):
+        for idx in range(len(self.minds)):
             # BUG: Number of minds could exceed number of plants?
             (mx, my) = self.plant_population[idx].get_pos()
             fuzzed_x = mx
@@ -296,12 +291,12 @@ class Game(object):
         
         if alive == 1:
             colors = ["red", "white", "purple", "yellow"]
-            print "Winner is %s (%s) in %s" % (self.mind_list[winner][1].name, 
-                                                colors[winner], str(self.time))
+            print("Winner is %s (%s) in %s" % (self.mind_list[winner][1].name,
+                                                colors[winner], str(self.time)))
             self.winner = winner
         
         if alive == 0 or (self.max_time > 0 and self.time > self.max_time):
-            print "It's a draw!"
+            print("It's a draw!")
             self.winner = -1
 
         self.agent_map.unlock()
@@ -322,8 +317,8 @@ class Game(object):
                          self.show_agents = not self.show_agents
                 elif event.type == pygame.locals.MOUSEBUTTONUP:
                     if event.button == 1:
-                        print self.agent_map.get(event.pos[0]/2,
-                                                 event.pos[1]/2)
+                        print(self.agent_map.get(event.pos[0] // 2,
+                                                 event.pos[1] // 2))
                 elif event.type == pygame.QUIT:
                     sys.exit()
             self.disp.update(self.terr, self.agent_population,
@@ -349,7 +344,7 @@ class Game(object):
         self.tic = time.time()
         self.clock.tick()
         if self.time % 100 == 0:
-            print 'FPS: %f' % self.clock.get_fps()
+            print('FPS: %f' % self.clock.get_fps())
 
 
 class MapLayer(object):
@@ -436,8 +431,8 @@ class ObjectMapLayer(MapLayer):
 
     def get_view(self, x, y, r):
         ret = []
-        for x_off in xrange(-r, r + 1):
-            for y_off in xrange(-r, r + 1):
+        for x_off in range(-r, r + 1):
+            for y_off in range(-r, r + 1):
                 if x_off == 0 and y_off == 0:
                     continue
                 a = self.get(x + x_off, y + y_off)
@@ -463,9 +458,7 @@ class ObjectMapLayer(MapLayer):
 # Otherwise, don't bother folks about it.
 try:
     import cells_helpers
-    import types
-    ObjectMapLayer.get_small_view_fast = types.MethodType(
-        cells_helpers.get_small_view_fast, None, ObjectMapLayer)
+    ObjectMapLayer.get_small_view_fast = cells_helpers.get_small_view_fast
 except ImportError:
     pass
 
@@ -643,12 +636,12 @@ class Display(object):
             #todo: find out how many teams are playing
             team_pop = [0] * nteams
 
-            for team in xrange(nteams):
+            for team in range(nteams):
                 team_pop[team] = sum(1 for a in pop if a.team == team)
 
             self.text = []
             drawTop = 0
-            for t in xrange(nteams):
+            for t in range(nteams):
                 drawTop += 20
                 self.show_text(str(team_pop[t]), TEAM_COLORS[t], (10, drawTop))
 
@@ -709,14 +702,14 @@ def main():
         symmetric = config.getboolean('terrain', 'symmetric')
         minds_str = str(config.get('minds', 'minds'))
     except Exception as e:
-        print 'Got error: %s' % e
+        print('Got error: %s' % e)
         config.add_section('minds')
         config.set('minds', 'minds', 'mind1,mind2')
         config.add_section('terrain')
         config.set('terrain', 'bounds', '300')
         config.set('terrain', 'symmetric', 'true')
 
-        with open('default.cfg', 'wb') as configfile:
+        with open('default.cfg', 'w') as configfile:
             config.write(configfile)
 
         config.read('default.cfg')

--- a/terrain/generator.py
+++ b/terrain/generator.py
@@ -3,15 +3,15 @@ import random
 import math
 
 class terrain_generator():
-    def create_random(self, size, range, symmetric=False):
+    def create_random(self, size, value_range, symmetric=False):
         """Creates a random terrain map"""
-        ret = numpy.random.random_integers(0, range, size)
+        ret = numpy.random.randint(0, value_range + 1, size)
 
         if symmetric:
             ret = self.make_symmetric(ret)
         return ret
 
-    def create_streak(self, size, range, symmetric=False):
+    def create_streak(self, size, value_range, symmetric=False):
         """Creates a terrain map containing streaks that run from north-west to south-east
 
            Starts with a single point [[a]] and converts it into [[a, b], [c, d]]
@@ -24,38 +24,38 @@ class terrain_generator():
         add_random_range = self.add_random_range
 
         # Creates the top row
-        ret = [[add_random_range(0, 0, range)]]
-        for x in xrange(size[0] - 1):
+        ret = [[add_random_range(0, 0, value_range)]]
+        for x in range(size[0] - 1):
             pos_west = ret[0][-1]
             if pos_west <= 0:
               ret[0].append(add_random_range(pos_west, 0, 1))
-            elif pos_west >= range:
+            elif pos_west >= value_range:
               ret[0].append(add_random_range(pos_west, -1, 0))
             else:
               ret[0].append(add_random_range(pos_west, -1, 1))
 
         # Create the next row down
-        for y in xrange(size[1] - 1):
+        for y in range(size[1] - 1):
             pos_north = ret[-1][0]
             if pos_north <= 0:
                 next_row = [add_random_range(pos_north, 0, 1)]
-            elif pos_north >= range:
+            elif pos_north >= value_range:
                 next_row = [add_random_range(pos_north,-1, 0)]
             else:
                 next_row = [add_random_range(pos_north, -1, 1)]
 
-            for x in xrange(size[0] - 1):
+            for x in range(size[0] - 1):
                 pos_north = ret[-1][x+1]
                 pos_west = next_row[-1]
                 if pos_west == pos_north:
                     if pos_west <= 0:
                         next_row.append(add_random_range(pos_west, 0, 1))
-                    elif pos_west >= range:
+                    elif pos_west >= value_range:
                         next_row.append(add_random_range(pos_west, -1, 0))
                     else:
                         next_row.append(add_random_range(pos_west, -1, 1))
                 elif abs(pos_west - pos_north) == 2:
-                    next_row.append((pos_west + pos_north)/2)
+                    next_row.append((pos_west + pos_north) // 2)
                 else:
                     next_row.append(random.choice((pos_west, pos_north)))
             ret.append(next_row)
@@ -64,7 +64,7 @@ class terrain_generator():
             ret = self.make_symmetric(ret)
         return numpy.array(ret)
 
-    def create_simple(self, size, range, symmetric=False):
+    def create_simple(self, size, value_range, symmetric=False):
         """Creates a procedural terrain map
 
            Starts with corner points [[a, b], [c, d]] and converts it into [[a, e, b], [f, g, h], [c, i, d]]
@@ -78,7 +78,7 @@ class terrain_generator():
            Repeat untill size is greater than required and truncate"""
         add_random_range = self.add_random_range
 
-        ret = [[add_random_range(0, 0, range), add_random_range(0, 0, range)], [add_random_range(0, 0, range), add_random_range(0, 0, range)]]
+        ret = [[add_random_range(0, 0, value_range), add_random_range(0, 0, value_range)], [add_random_range(0, 0, value_range), add_random_range(0, 0, value_range)]]
 
         while len(ret) <= size[0]:
             new_ret = []
@@ -90,10 +90,10 @@ class terrain_generator():
                     next_row = []
                     for key_y, pos_south in enumerate(x):
                         pos_north = ret[key_x+1][key_y]
-                        pos_avg = (pos_north + pos_south)/2
+                        pos_avg = (pos_north + pos_south) // 2
                         if pos_avg <= 0:
                             next_row.append(add_random_range(pos_avg, 0, 1))
-                        elif pos_avg >= range:
+                        elif pos_avg >= value_range:
                             next_row.append(add_random_range(pos_avg, -1, 0))
                         else:
                             next_row.append(add_random_range(pos_avg, -1, 1))
@@ -108,18 +108,18 @@ class terrain_generator():
                     if key_x % 2 and not key_y % 2:
                         pos_north = ret[key_x-1][key_y+1]
                         pos_south = ret[key_x+1][key_y+1]
-                        pos_avg = (pos_north + pos_south + pos_east + pos_west)/4
+                        pos_avg = (pos_north + pos_south + pos_east + pos_west) // 4
                         if pos_avg <= 0:
                             next_row.append(add_random_range(pos_avg, 0, 1))
-                        elif pos_avg >= range:
+                        elif pos_avg >= value_range:
                             next_row.append(add_random_range(pos_avg, -1, 0))
                         else:
                             next_row.append(add_random_range(pos_avg, -1, 1))
                     else:
-                        pos_avg = (pos_east + pos_west)/2
+                        pos_avg = (pos_east + pos_west) // 2
                         if pos_avg <= 0:
                             next_row.append(add_random_range(pos_avg, 0, 1))
-                        elif pos_avg >= range:
+                        elif pos_avg >= value_range:
                             next_row.append(add_random_range(pos_avg, -1, 0))
                         else:
                             next_row.append(add_random_range(pos_avg, -1, 1))
@@ -132,7 +132,7 @@ class terrain_generator():
         if symmetric:
             ret = self.make_symmetric(ret)
         return numpy.array(ret)
-    
+
     def create_perlin(self, size, roughness, symmetric = False):
         (width, height) = size
         values = numpy.zeros(size)
@@ -145,21 +145,21 @@ class terrain_generator():
                     continue
                 nr = 1
                 for i in octaves:
-                    top = y/i
-                    left = x/i
+                    top = y // i
+                    left = x // i
                     my = float(y % i) / i
                     mx = float(x % i) / i
                     values[x][y] += self.interpolate(noise[top][left], noise[top][left+1], noise[top+1][left], noise[top+1][left+1], mx, my) * math.pow(0.5, nr)
                     nr += 1
                 values[x][y] = int(values[x][y] * roughness)
         return numpy.array(values,dtype=int)
-    
+
     #Some helper functions.
     def interpolate(self, p1, p2, p3, p4, x, y):
         top = self.interpolate1d(p1, p2, x)
         bottom = self.interpolate1d(p3, p4, x)
         return self.interpolate1d(top, bottom, y)
-        
+
     def interpolate1d(self, p1, p2, mu):
         return p1*(1-mu)+p2*mu
 
@@ -169,8 +169,8 @@ class terrain_generator():
 
     def make_symmetric(self, ret):
         """Takes a 2-dimentional list and makes it symmetrical about the north-west / south-east axis"""
-        for x in xrange(len(ret)):
-            for y in xrange(x):
+        for x in range(len(ret)):
+            for y in range(x):
                 ret[x][y] = ret[y][x]
 
         return ret

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,148 @@
+"""Headless smoke tests for the cells engine.
+
+These tests don't import any user mind modules - they use stub AgentMind
+classes that exercise specific action types. The goal is to prove the
+engine ticks and applies each action without crashing.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import random
+
+import numpy
+import pytest
+
+import cells
+
+
+def _seed(n=1):
+    random.seed(n)
+    numpy.random.seed(n)
+
+
+def _module(name, mind_cls):
+    """Wrap a mind class in a module-like object so cells.Game can use it.
+
+    cells.Game expects mind_list entries shaped like (name, module) where
+    module exposes both AgentMind and a `name` attribute (set by get_mind).
+    """
+
+    class M:
+        pass
+
+    m = M()
+    m.AgentMind = mind_cls
+    m.name = name
+    return (name, m)
+
+
+class EatMind:
+    def __init__(self, cargs):
+        pass
+
+    def act(self, view, msg):
+        return cells.Action(cells.ACT_EAT)
+
+
+def test_module_exports_legacy_api():
+    """Minds rely on these symbols - keep them stable."""
+    assert cells.ACT_SPAWN == 0
+    assert cells.ACT_MOVE == 1
+    assert cells.ACT_EAT == 2
+    assert cells.ACT_RELEASE == 3
+    assert cells.ACT_ATTACK == 4
+    assert cells.ACT_LIFT == 5
+    assert cells.ACT_DROP == 6
+    assert cells.STARTING_ENERGY == 20
+    assert cells.SPAWN_TOTAL_ENERGY == cells.BODY_ENERGY + cells.SPAWN_LOST_ENERGY
+    assert hasattr(cells, "Action")
+    assert hasattr(cells, "Game")
+
+
+def test_game_runs_to_draw_on_max_time():
+    """Two stub minds that only eat will both survive until max_time."""
+    _seed()
+    g = cells.Game(
+        50,
+        [_module("a", EatMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=80,
+        headless=True,
+    )
+    ticks = 0
+    while g.winner is None and ticks < 500:
+        g.tick()
+        ticks += 1
+    assert g.winner is not None
+    assert g.winner == -1  # draw on max_time
+    assert ticks >= 80
+
+
+class AttackEverythingMind:
+    """Attack any visible enemy, otherwise eat."""
+
+    def __init__(self, cargs):
+        pass
+
+    def act(self, view, msg):
+        me = view.get_me()
+        for a in view.get_agents():
+            if a.get_team() != me.get_team():
+                return cells.Action(cells.ACT_ATTACK, a.get_pos())
+        return cells.Action(cells.ACT_EAT)
+
+
+def test_attack_action_is_applied():
+    """Place two attacking minds adjacent; one should kill the other."""
+    _seed(2)
+    g = cells.Game(
+        20,
+        [_module("a", AttackEverythingMind), _module("b", AttackEverythingMind)],
+        symmetric=True,
+        max_time=200,
+        headless=True,
+    )
+    ticks = 0
+    while g.winner is None and ticks < 500:
+        g.tick()
+        ticks += 1
+    assert g.winner is not None
+
+
+class CycleMind:
+    """Cycle through action types to exercise the dispatch table."""
+
+    def __init__(self, cargs):
+        self.i = 0
+
+    def act(self, view, msg):
+        me = view.get_me()
+        x, y = me.get_pos()
+        actions = [
+            cells.Action(cells.ACT_EAT),
+            cells.Action(cells.ACT_MOVE, (x + 1, y)),
+            cells.Action(cells.ACT_LIFT),
+            cells.Action(cells.ACT_DROP),
+            cells.Action(cells.ACT_RELEASE, (x + 1, y, 1)),
+        ]
+        a = actions[self.i % len(actions)]
+        self.i += 1
+        return a
+
+
+def test_all_action_types_dispatch_without_crash():
+    _seed(3)
+    g = cells.Game(
+        30,
+        [_module("a", CycleMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=60,
+        headless=True,
+    )
+    ticks = 0
+    while g.winner is None and ticks < 200:
+        g.tick()
+        ticks += 1
+    assert ticks > 0

--- a/tests/test_terrain_generator.py
+++ b/tests/test_terrain_generator.py
@@ -1,0 +1,40 @@
+import numpy
+import pytest
+
+from terrain.generator import terrain_generator
+
+
+@pytest.fixture
+def gen():
+    return terrain_generator()
+
+
+def test_create_random_shape_and_range(gen):
+    numpy.random.seed(0)
+    arr = gen.create_random((20, 20), 10)
+    assert arr.shape == (20, 20)
+    assert arr.dtype.kind in ("i", "u")
+    assert arr.min() >= 0 and arr.max() <= 10
+
+
+def test_create_perlin_shape_and_dtype(gen):
+    numpy.random.seed(0)
+    arr = gen.create_perlin((30, 30), 10)
+    assert arr.shape == (30, 30)
+    assert arr.dtype == int
+
+
+def test_create_streak_runs(gen):
+    arr = gen.create_streak((20, 20), 5)
+    assert numpy.asarray(arr).shape == (20, 20)
+
+
+def test_create_simple_runs(gen):
+    arr = gen.create_simple((16, 16), 5)
+    assert numpy.asarray(arr).shape == (16, 16)
+
+
+def test_symmetry(gen):
+    numpy.random.seed(0)
+    arr = gen.create_perlin((16, 16), 10, symmetric=True)
+    assert numpy.array_equal(arr, arr.T)


### PR DESCRIPTION
- Replace removed numpy.random.random_integers with numpy.random.randint
  (compensating for the inclusive-vs-exclusive high bound).
- Switch xrange to range throughout.
- Use floor division (//) for averages and octave indices that are used
  to index numpy arrays; Python 3's / now returns float.
- Rename the 'range' parameter to 'value_range' on create_random,
  create_streak, and create_simple to avoid shadowing the now-used
  range builtin.

Adds tests/test_terrain_generator.py exercising shape, dtype, value
range, and NW-SE symmetry across all four generators.