### PR TITLE
Add CLI flags and headless exit semantics (#5)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -693,9 +693,49 @@ class Message(object):
         return self.message
 
 
-def main():
+def _parse_cli(argv=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Cells: a multi-agent Python programming game.",
+    )
+    parser.add_argument(
+        "minds",
+        nargs="*",
+        help="Mind module names from minds/. Need 2+ to override default.cfg.",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run without opening a display window. Exits after one game.",
+    )
+    parser.add_argument(
+        "--max-time",
+        type=int,
+        default=None,
+        help="Tick limit. Default: -1 (no limit) with display, 5000 headless.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed random and numpy.random for reproducible runs.",
+    )
+    args = parser.parse_args(argv)
+    if args.max_time is None:
+        args.max_time = 5000 if args.headless else -1
+    return args
+
+
+def main(argv=None):
     global bounds, symmetric, mind_list
-    
+
+    args = _parse_cli(argv)
+
+    if args.seed is not None:
+        random.seed(args.seed)
+        numpy.random.seed(args.seed)
+
     try:
         config.read('default.cfg')
         bounds = config.getint('terrain', 'bounds')
@@ -716,19 +756,20 @@ def main():
         bounds = config.getint('terrain', 'bounds')
         symmetric = config.getboolean('terrain', 'symmetric')
         minds_str = str(config.get('minds', 'minds'))
-    mind_list = [(n, get_mind(n)) for n in minds_str.split(',')]
 
-    # accept command line arguments for the minds over those in the config
-    try:
-        if len(sys.argv)>2:
-            mind_list = [(n,get_mind(n)) for n in sys.argv[1:] ]
-    except (ImportError, IndexError):
-        pass
+    if len(args.minds) >= 2:
+        mind_list = [(n, get_mind(n)) for n in args.minds]
+    else:
+        mind_list = [(n, get_mind(n)) for n in minds_str.split(',')]
+
+    return args
 
 
 if __name__ == "__main__":
-    main()
+    args = main()
     while True:
-        game = Game(bounds, mind_list, symmetric, -1)
+        game = Game(bounds, mind_list, symmetric, args.max_time, headless=args.headless)
         while game.winner is None:
             game.tick()
+        if args.headless:
+            break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+"""End-to-end tests for the cells CLI entry point.
+
+The engine + display + config wiring is exercised by spawning the
+script as a subprocess so the __main__ path is covered, including
+argparse, the restart loop break for headless, and the auto-creation
+of default.cfg.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _run(args, cwd, timeout=30):
+    return subprocess.run(
+        [sys.executable, str(REPO / "cells.py"), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_headless_run_with_explicit_minds(tmp_path):
+    """--headless --max-time --seed exits cleanly with mind names on argv."""
+    result = _run(
+        ["--headless", "--max-time", "30", "--seed", "1", "mind1", "mind2"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "It's a draw!" in result.stdout or "Winner is" in result.stdout
+
+
+def test_headless_creates_default_cfg_when_missing(tmp_path):
+    """Running with no positional args and no config file should auto-create one."""
+    cfg = tmp_path / "default.cfg"
+    assert not cfg.exists()
+    result = _run(
+        ["--headless", "--max-time", "20", "--seed", "2"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert cfg.exists(), "default.cfg was not created"
+    contents = cfg.read_text()
+    assert "[minds]" in contents
+    assert "[terrain]" in contents
+    assert "minds = mind1,mind2" in contents
+
+
+def test_help_flag_exits_zero(tmp_path):
+    result = _run(["--help"], cwd=tmp_path)
+    assert result.returncode == 0
+    assert "--headless" in result.stdout
+    assert "--max-time" in result.stdout
+    assert "--seed" in result.stdout


### PR DESCRIPTION
Closes #5.

## Summary
- Adds `argparse` to `cells.py` with three new flags: `--headless`, `--max-time N`, `--seed N`.
- Headless runs skip `Display` construction and exit after one game (instead of the legacy infinite restart loop, which only made sense with a keyboard).
- `--max-time` defaults to `5000` headless and `-1` (no limit) with display, matching `tournament.py` and the legacy default.
- `--seed` seeds both `random` and `numpy.random` for reproducible runs.
- Positional mind names still override `default.cfg` when 2+ are supplied; otherwise the config is read (and auto-created on first run) as before.

## Test plan
- [x] `SDL_VIDEODRIVER=dummy python -m pytest tests/test_cli.py -v` → 3/3 pass.
- [x] Manual: `python cells.py --headless --max-time 30 --seed 1 mind1 mind2` exits with `It's a draw!` in a fresh directory and creates `default.cfg`.
- [x] Manual: `python cells.py --help` prints the new flags.
- [ ] Display path: `python cells.py mind1 mind2` opens a window. (Cannot verify in this sandbox — needs a real display.)

## Notes
- The legacy `len(sys.argv) > 2` rule is preserved (1 positional arg silently falls back to config), but argparse exposes `--help` cleanly.
- I haven't touched display rendering — the GUI path runs the same code as before, just gated on `not args.headless`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_