### PR TITLE
Port tournament.py to Python 3 (#8)

### DIFF
--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,0 +1,129 @@
+"""End-to-end tests for the tournament runner.
+
+The script is exercised via subprocess so the __main__ path is covered,
+including argparse, the config auto-create, the round-robin loop, and the
+scores.csv writer. Tests use small bounds and short max-time to keep the
+suite fast in CI.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _run(args, cwd, timeout=120):
+    return subprocess.run(
+        [sys.executable, str(REPO / "tournament.py"), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _write_small_cfg(tmp_path, bounds=30, symmetric="true"):
+    (tmp_path / "tournament.cfg").write_text(
+        "[minds]\n"
+        "minds = mind1,mind2\n"
+        "[terrain]\n"
+        f"bounds = {bounds}\n"
+        f"symmetric = {symmetric}\n"
+    )
+
+
+def test_tournament_writes_scores_csv(tmp_path):
+    _write_small_cfg(tmp_path)
+    result = _run(
+        [
+            "--seed", "1",
+            "--rounds", "1",
+            "--max-time", "30",
+            "mind1", "mind2", "mind3",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    csv = tmp_path / "scores.csv"
+    assert csv.exists()
+    rows = [r for r in csv.read_text().splitlines() if r.strip()]
+    assert len(rows) == 3
+    names = []
+    for row in rows:
+        name, score = row.split(";")
+        assert name in {"mind1", "mind2", "mind3"}
+        assert int(score) >= 0
+        names.append(name)
+    assert sorted(names) == ["mind1", "mind2", "mind3"]
+
+
+def test_tournament_creates_cfg_when_missing(tmp_path):
+    cfg = tmp_path / "tournament.cfg"
+    assert not cfg.exists()
+    result = _run(
+        ["--seed", "2", "--rounds", "1", "--max-time", "20"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert cfg.exists(), "tournament.cfg was not auto-created"
+    contents = cfg.read_text()
+    assert "[minds]" in contents
+    assert "[terrain]" in contents
+    assert "minds = mind1,mind2" in contents
+    assert "bounds = 300" in contents
+
+
+def test_tournament_score_total_within_expected_range(tmp_path):
+    """rounds * games_per_round * 3 is the win-only ceiling;
+    rounds * games_per_round * 2 is the all-draws floor."""
+    _write_small_cfg(tmp_path)
+    rounds = 2
+    minds = ["mind1", "mind2", "mind3"]
+    games_per_round = len(minds) * (len(minds) - 1) // 2
+    result = _run(
+        [
+            "--seed", "3",
+            "--rounds", str(rounds),
+            "--max-time", "30",
+            *minds,
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    csv = tmp_path / "scores.csv"
+    rows = [r for r in csv.read_text().splitlines() if r.strip()]
+    total = sum(int(r.split(";")[1]) for r in rows)
+    expected_low = rounds * games_per_round * 2
+    expected_high = rounds * games_per_round * 3
+    assert expected_low <= total <= expected_high
+
+
+def test_tournament_scores_sorted_descending(tmp_path):
+    _write_small_cfg(tmp_path)
+    result = _run(
+        [
+            "--seed", "4",
+            "--rounds", "1",
+            "--max-time", "30",
+            "mind1", "mind2", "mind3",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    csv = tmp_path / "scores.csv"
+    rows = [r for r in csv.read_text().splitlines() if r.strip()]
+    scores = [int(r.split(";")[1]) for r in rows]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_tournament_help_flag(tmp_path):
+    result = _run(["--help"], cwd=tmp_path)
+    assert result.returncode == 0
+    assert "--rounds" in result.stdout
+    assert "--max-time" in result.stdout
+    assert "--seed" in result.stdout
+    assert "--output" in result.stdout

--- a/tournament.py
+++ b/tournament.py
@@ -1,78 +1,122 @@
 #!/usr/bin/env python
+"""Round-robin tournament runner for cells.
 
+Plays each pair of minds in mind_list against each other for a configurable
+number of rounds, accumulating scores (3 for a win, 1 for each side on a
+draw). Writes scores.csv sorted by score descending.
+"""
+
+import argparse
+import configparser
+import random
 import sys
-import ConfigParser
-from cells import Game
 
-config = ConfigParser.RawConfigParser()
+import numpy
 
-def get_mind(name):
-    full_name = 'minds.' + name
-    __import__(full_name)
-    mind = sys.modules[full_name]
-    mind.name = name
-    return mind
+from cells import Game, get_mind
 
-bounds = None  # HACK
-symmetric = None
-mind_list = None
 
-def main():
-    global bounds, symmetric, mind_list
+def _parse_cli(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Cells round-robin tournament.",
+    )
+    parser.add_argument(
+        "minds",
+        nargs="*",
+        help="Mind module names from minds/. Need 2+ to override tournament.cfg.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed random and numpy.random for reproducible runs.",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=4,
+        help="Number of round-robin rounds. Default: 4.",
+    )
+    parser.add_argument(
+        "--max-time",
+        type=int,
+        default=5000,
+        help="Tick limit per game. Default: 5000.",
+    )
+    parser.add_argument(
+        "--output",
+        default="scores.csv",
+        help="Output CSV path. Default: scores.csv.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_config(path="tournament.cfg"):
+    config = configparser.RawConfigParser()
     try:
-        config.read('tournament.cfg')
-        bounds = config.getint('terrain', 'bounds')
-        symmetric = config.getboolean('terrain', 'symmetric')
-        minds_str = str(config.get('minds', 'minds'))
-
+        config.read(path)
+        bounds = config.getint("terrain", "bounds")
+        symmetric = config.getboolean("terrain", "symmetric")
+        minds_str = str(config.get("minds", "minds"))
     except Exception as e:
-        print 'Got error: %s' % e
-        config.add_section('minds')
-        config.set('minds', 'minds', 'mind1,mind2')
-        config.add_section('terrain')
-        config.set('terrain', 'bounds', '300')
-        config.set('terrain', 'symmetric', 'true')
-
-        with open('tournament.cfg', 'wb') as configfile:
-            config.write(configfile)
-
-        config.read('tournament.cfg')
-        bounds = config.getint('terrain', 'bounds')
-        symmetric = config.getboolean('terrain', 'symmetric')
-        minds_str = str(config.get('minds', 'minds'))
-    mind_list = [(n, get_mind(n)) for n in minds_str.split(',')]
-
-    # accept command line arguments for the minds over those in the config
-    try:
-        if len(sys.argv)>2:
-            mind_list = [(n,get_mind(n)) for n in sys.argv[1:] ]
-    except (ImportError, IndexError):
-        pass
+        print("Got error: %s" % e)
+        config = configparser.RawConfigParser()
+        config.add_section("minds")
+        config.set("minds", "minds", "mind1,mind2")
+        config.add_section("terrain")
+        config.set("terrain", "bounds", "300")
+        config.set("terrain", "symmetric", "true")
+        with open(path, "w") as f:
+            config.write(f)
+        bounds = config.getint("terrain", "bounds")
+        symmetric = config.getboolean("terrain", "symmetric")
+        minds_str = str(config.get("minds", "minds"))
+    return bounds, symmetric, [n.strip() for n in minds_str.split(",") if n.strip()]
 
 
-if __name__ == "__main__":
-    main()
-    scores = [0 for x in mind_list]
-    tournament_list = [[mind_list[a], mind_list[b]] for a in range(len(mind_list)) for b in range (a)]
-    for n in range(4):
-        for pair in tournament_list:
-            game = Game(bounds, pair, symmetric, 5000, headless = True)
-            while game.winner == None:
+def main(argv=None):
+    args = _parse_cli(argv)
+
+    if args.seed is not None:
+        random.seed(args.seed)
+        numpy.random.seed(args.seed)
+
+    bounds, symmetric, cfg_minds = _load_config()
+
+    if len(args.minds) >= 2:
+        names = args.minds
+    else:
+        names = cfg_minds
+
+    mind_list = [(n, get_mind(n)) for n in names]
+
+    scores = [0 for _ in mind_list]
+    pairings = [
+        [mind_list[a], mind_list[b]]
+        for a in range(len(mind_list))
+        for b in range(a)
+    ]
+
+    for round_idx in range(args.rounds):
+        for pair in pairings:
+            game = Game(bounds, pair, symmetric, args.max_time, headless=True)
+            while game.winner is None:
                 game.tick()
             if game.winner >= 0:
                 idx = mind_list.index(pair[game.winner])
                 scores[idx] += 3
-            if game.winner == -1:
-                idx = mind_list.index(pair[0])
-                scores[idx] += 1
-                idx = mind_list.index(pair[1])
-                scores[idx] += 1
-            print scores
-            print [m[0] for m in mind_list]
-    names = [m[0] for m in mind_list]
-    name_score = zip(names,scores)
-    f = open("scores.csv",'w')
-    srt = sorted(name_score,key=lambda ns: -ns[1])
-    for x in srt:
-        f.write("%s;%s\n" %(x[0],str(x[1])))
-    f.close()
+            elif game.winner == -1:
+                scores[mind_list.index(pair[0])] += 1
+                scores[mind_list.index(pair[1])] += 1
+            print(scores)
+            print([m[0] for m in mind_list])
+
+    name_score = list(zip([m[0] for m in mind_list], scores))
+    name_score.sort(key=lambda ns: -ns[1])
+    with open(args.output, "w") as f:
+        for name, score in name_score:
+            f.write("%s;%s\n" % (name, score))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #8.

## Summary
- `tournament.py` — argparse + configparser + `print()` + `with open()` context manager. Same scoring (3 win / 1 draw apiece), same lower-triangle round-robin pairings, same `tournament.cfg` schema with auto-create-on-missing, same `scores.csv` `name;score` format sorted descending.
- Preserves the explicit `while game.winner is None: game.tick()` loop shape so the future asyncio port (#18) can drop in without restructuring the runner.
- Adds `--rounds`, `--max-time`, `--seed`, `--output` CLI flags. Defaults match the spec (4 rounds, 5000 ticks, `scores.csv`); the flags exist so the test suite can run a tractable game in CI.

## Test plan
- [x] `python -m pytest tests/test_tournament.py -v` → 5/5 pass in 2.5s.
- [x] Full suite (`SDL_VIDEODRIVER=dummy python -m pytest -v`) → 21/21 pass in 2.9s.
- [x] `python tournament.py mind1 mind2 mind3 --seed 1 --rounds 1 --max-time 30` writes a 3-row `scores.csv` with no window.

## Notes
- New tests cover: csv row count, auto-cfg creation, score-total bounds (`rounds * games * 2 ≤ total ≤ rounds * games * 3`), descending sort, `--help`.
- The `4 * 3 * 3 = 36` total claim from the issue spec assumes no draws — relaxed to a range in tests so flakiness doesn't bite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_