### PR TITLE
Consolidate Game.tick events + cover Display under SDL dummy (#4)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -303,22 +303,21 @@ class Game(object):
         
     def tick(self):
         if not self.headless:
-            # Space starts new game
-            # q or close button will quit the game
+            scale = self.disp.scale
             for event in pygame.event.get():
                 if event.type == pygame.locals.KEYUP:
                     if event.key == pygame.locals.K_SPACE:
                         self.winner = -1
                     elif event.key == pygame.locals.K_q:
-                         sys.exit()
+                        sys.exit()
                     elif event.key == pygame.locals.K_e:
-                         self.show_energy = not self.show_energy
+                        self.show_energy = not self.show_energy
                     elif event.key == pygame.locals.K_a:
-                         self.show_agents = not self.show_agents
+                        self.show_agents = not self.show_agents
                 elif event.type == pygame.locals.MOUSEBUTTONUP:
                     if event.button == 1:
-                        print(self.agent_map.get(event.pos[0] // 2,
-                                                 event.pos[1] // 2))
+                        print(self.agent_map.get(event.pos[0] // scale,
+                                                 event.pos[1] // scale))
                 elif event.type == pygame.QUIT:
                     sys.exit()
             self.disp.update(self.terr, self.agent_population,
@@ -326,13 +325,6 @@ class Game(object):
                              self.plant_map, self.energy_map, self.time,
                              len(self.minds), self.show_energy,
                              self.show_agents)
-            
-            # test for spacebar pressed - if yes, restart
-            for event in pygame.event.get(pygame.locals.KEYUP):
-                if event.key == pygame.locals.K_SPACE:
-                    self.winner = -1
-            if pygame.event.get(pygame.locals.QUIT):
-                sys.exit()
             pygame.event.pump()
             self.disp.flip()
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,116 @@
+"""Tests for the Display class and the GUI half of Game.tick.
+
+Uses SDL_VIDEODRIVER=dummy so pygame works without a real display server.
+Hotkey wiring is verified by injecting events into the queue with
+pygame.event.post() and running one tick.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pathlib
+import sys
+
+import pygame
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+import cells  # noqa: E402
+from minds import mind1  # noqa: E402
+
+pygame.init()
+
+
+@pytest.fixture
+def display_game():
+    """Headed game with a tiny grid and the dummy SDL driver."""
+    mind1.name = "mind1"
+    game = cells.Game(
+        bounds=20,
+        mind_list=[("mind1", mind1), ("mind1", mind1)],
+        symmetric=True,
+        max_time=200,
+        headless=False,
+    )
+    pygame.event.clear()
+    yield game
+    pygame.event.clear()
+
+
+def test_display_constructs_without_real_display(display_game):
+    assert display_game.disp is not None
+    assert display_game.disp.scale == 2
+    assert display_game.disp.size == (40, 40)
+
+
+def test_display_update_and_flip_run(display_game):
+    display_game.disp.update(
+        display_game.terr,
+        display_game.agent_population,
+        display_game.plant_population,
+        display_game.agent_map,
+        display_game.plant_map,
+        display_game.energy_map,
+        ticks=0,
+        nteams=len(display_game.minds),
+        show_energy=True,
+        show_agents=True,
+    )
+    display_game.disp.flip()
+
+
+def test_space_key_resets_winner(display_game):
+    pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_SPACE}))
+    display_game.tick()
+    assert display_game.winner == -1
+
+
+def test_e_key_toggles_show_energy(display_game):
+    initial = display_game.show_energy
+    pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_e}))
+    display_game.tick()
+    assert display_game.show_energy != initial
+
+
+def test_a_key_toggles_show_agents(display_game):
+    initial = display_game.show_agents
+    pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_a}))
+    display_game.tick()
+    assert display_game.show_agents != initial
+
+
+def test_left_click_uses_display_scale_for_lookup(display_game, capfd):
+    """Click at scaled coords (10, 10) should look up cell (5, 5) given scale=2."""
+    pygame.event.post(
+        pygame.event.Event(
+            pygame.MOUSEBUTTONUP,
+            {"button": 1, "pos": (10, 10)},
+        )
+    )
+    display_game.tick()
+    out, _ = capfd.readouterr()
+    # Either prints "None" (empty cell) or "Agent from team ...".
+    assert "None" in out or "Agent from team" in out
+
+
+def test_quit_key_q_calls_sys_exit(display_game):
+    pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_q}))
+    with pytest.raises(SystemExit):
+        display_game.tick()
+
+
+def test_quit_event_calls_sys_exit(display_game):
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    with pytest.raises(SystemExit):
+        display_game.tick()
+
+
+def test_display_handles_many_ticks(display_game):
+    """Smoke test: 60 ticks triggers the team-population text refresh."""
+    for _ in range(65):
+        if display_game.winner is not None:
+            break
+        display_game.tick()


### PR DESCRIPTION
Closes #4.

## Summary
- `cells.py` `Game.tick`: collapse the two-pass `pygame.event.get()` loop into one. The legacy code drained the queue once before render (KEYUP / MOUSEBUTTONUP / QUIT) and again after render for a redundant `K_SPACE` / `QUIT` check — the second pass was dead code. Now: one pass, then update + pump + flip.
- Left-click coordinate lookup uses `// self.disp.scale` instead of the hardcoded `// 2`. Behavior is unchanged at the default scale=2 but no longer breaks if someone constructs a `Display` with a different scale.
- New `tests/test_display.py` (9 tests) — covers Display construction under `SDL_VIDEODRIVER=dummy`, `update()` + `flip()`, and the hotkey wiring (`K_SPACE`, `K_q`, `K_e`, `K_a`, `MOUSEBUTTONUP`, `QUIT`) by injecting events with `pygame.event.post()` and running one tick.

The `Display` class itself was already ported during #3 — verifying it works headless under the dummy SDL driver was the missing piece.

## Test plan
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 30/30 pass in 4.5s.
- [x] Display tests run on Python 3.11 without a real X11/Wayland display server.
- [ ] Local `python cells.py mind1 mind2` (with a display) — not run in CI; visual verification only.

## Notes
- Display unit tests don't compare pixel output (pygame surface arrays are noisy across versions); they assert that the calls don't crash and that hotkeys flip the right state. That's the reasonable bar — the spec contract is "behavior", not "exact pixels".
- `K_q` and `QUIT` tests use `pytest.raises(SystemExit)` — `sys.exit()` is the legacy contract and the engine still relies on it for the `cells.py __main__` restart loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_