### PR TITLE
Repo cleanup: dead code, docs, .gitignore (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.c
 *.so
 build
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.venv/

--- a/DOCUMENTATION
+++ b/DOCUMENTATION
@@ -32,14 +32,14 @@ method, but remember, when calling another method to determine what
 action to take, you must have a chain of return statements leading all
 the way back to the AgentMind.act method.
 
-If you don't you'll get a an error that looks like this:
+If you don't you'll get an error that looks like this:
 
 Traceback (most recent call last):
-  File "cells.py", line 570, in <module>
+  File "cells.py", in <module>
     game.tick()
-  File "cells.py", line 242, in tick
+  File "cells.py", in tick
     self.run_agents()
-  File "cells.py", line 158, in run_agents
+  File "cells.py", in run_agents
     if action.type == ACT_MOVE: # Changes position of agent.
 AttributeError: 'NoneType' object has no attribute 'type'
 

--- a/README
+++ b/README
@@ -1,21 +1,36 @@
-Cells is a multi agent programing game written in Python.
+Cells is a multi-agent programming game written in Python.
 
-For more information see: http://phonons.wordpress.com/2010/06/01/cells-a-massively-multi-agent-python-programming-game/
+For background see: http://phonons.wordpress.com/2010/06/01/cells-a-massively-multi-agent-python-programming-game/
 
-Join #pycells on irc.freenode.net to discuss Cells
+Requirements: Python 3.11+, numpy, pygame.
 
-Requirements:
-pygame
-numpy
+Install:
+    pip install -r requirements.txt
 
-Optional:
-psyco
+Run a game with a display:
+    python cells.py mind1 mind2
 
-To run:
-python cells.py <program1> ... <programN> 
+Run headless (no window, exits after one game):
+    python cells.py --headless --max-time 200 mind1 mind2
 
-For example:
+Run a round-robin tournament (writes scores.csv):
+    python tournament.py mind1 mind2 mind3
 
-python cells.py mind1 mind2
+Hotkeys (display mode):
+    space   restart the game
+    q       quit
+    e       toggle the energy overlay
+    a       toggle the agent overlay
+    click   print the agent at the clicked cell
 
-For available minds, look in the minds/ folder. Also place your custom minds there.
+For the mind authoring API, see DOCUMENTATION. For tournament rules, see CHEATING.
+
+For available minds, look in the minds/ folder. Place your custom mind there as
+a Python module that exposes an AgentMind class.
+
+Optional Cython speedup (engine has a pure-Python fallback):
+    pip install -r requirements-dev.txt
+    python setup.py build_ext --inplace
+
+Tests:
+    SDL_VIDEODRIVER=dummy python -m pytest -v

--- a/cells.py
+++ b/cells.py
@@ -389,7 +389,6 @@ class ObjectMapLayer(MapLayer):
         self.surf.set_colorkey((0,0,0))
         self.surf.fill((0,0,0))
         self.pixels = None
-#        self.pixels = pygame.PixelArray(self.surf)
 
     def lock(self):
         self.pixels = pygame.surfarray.pixels2d(self.surf)
@@ -596,24 +595,16 @@ class Display(object):
 
     def update(self, terr, pop, plants, agent_map, plant_map, energy_map,
                ticks, nteams, show_energy, show_agents):
-        # Slower version:
-        # img = ((numpy.minimum(150, 20 * terr.values) << 16) +
-        #       ((numpy.minimum(150, 10 * terr.values + 10.energy_map.values)) << 8))
-         
         r = numpy.minimum(150, 20 * terr.values)
         r <<= 16
 
-#        g = numpy.minimum(150, 10 * terr.values + 10 * energy_map.values)
+        img = r
         if show_energy:
             g = terr.values + energy_map.values
             g *= 10
             g = numpy.minimum(150, g)
             g <<= 8
-
-        img = r
-        if show_energy:
             img += g
- #       b = numpy.zeros_like(terr.values)
 
         img_surf = pygame.Surface((self.width, self.height))
         pygame.surfarray.blit_array(img_surf, img)
@@ -720,8 +711,6 @@ def _parse_cli(argv=None):
 
 
 def main(argv=None):
-    global bounds, symmetric, mind_list
-
     args = _parse_cli(argv)
 
     if args.seed is not None:
@@ -754,11 +743,11 @@ def main(argv=None):
     else:
         mind_list = [(n, get_mind(n)) for n in minds_str.split(',')]
 
-    return args
+    return args, bounds, symmetric, mind_list
 
 
 if __name__ == "__main__":
-    args = main()
+    args, bounds, symmetric, mind_list = main()
     while True:
         game = Game(bounds, mind_list, symmetric, args.max_time, headless=args.headless)
         while game.winner is None:


### PR DESCRIPTION
Closes #12.

## Summary
- **`cells.py`**: drop the commented `PixelArray` init, the "Slower version" comment block, and two adjacent dead alternate-form comments inside `Display.update`. Combine the two `if show_energy` blocks (one for computing `g`, one for `img += g`) into a single block.
- **`cells.py main()`**: return `(args, bounds, symmetric, mind_list)` instead of mutating module globals. The `__main__` block unpacks and uses them. No callers depend on the globals (verified via `grep cells\.bounds` etc).
- **`.gitignore`**: add `__pycache__/`, `*.egg-info/`, `.pytest_cache/`, `.venv/`.
- **`README`**: replace the 22-line legacy README with a Python 3 install/run guide. Covers display + headless + tournament + hotkeys + tests + optional Cython build.
- **`DOCUMENTATION`**: drop the stale line numbers from the traceback example so it doesn't keep going out of date with the engine.

## Test plan
- [x] `git grep -i 'psyco\|xrange\|iteritems\|ConfigParser '` against `cells.py` / `tournament.py` / `terrain/` → no matches.
- [x] `git status` after a test run no longer surfaces `__pycache__/` directories.
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 30/30 pass.
- [x] `python cells.py mind1 mind2 --headless --max-time 30 --seed 1` still runs to completion (entry-point refactor verified by the existing `tests/test_cli.py` subprocess tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_