### PR TITLE
Convert engine to asyncio with sync mind compatibility (#18)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
+import asyncio
+import collections
 import configparser
+import inspect
 import random
 import sys
 import time
@@ -20,6 +23,80 @@ def get_mind(name):
     mind = sys.modules[full_name]
     mind.name = name
     return mind
+
+
+SOFT_TIMEOUT_SECONDS = 5.0
+HARD_TIMEOUT_SECONDS = 60.0
+
+
+async def _call_act(act_fn, view, msg):
+    """Invoke a mind's act() under a 60s hard ceiling.
+
+    Works with both sync (`def act`) and async (`async def act`) minds:
+    if the return value is awaitable, await it; otherwise return as-is.
+    Cancellation propagates so the caller's wait_for can shield without
+    leaking tasks past game end.
+    """
+    async with asyncio.timeout(HARD_TIMEOUT_SECONDS):
+        result = act_fn(view, msg)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+def _enqueue_actions(agent, result):
+    if result is None:
+        return
+    if isinstance(result, list):
+        agent.action_queue.extend(a for a in result if a is not None)
+    else:
+        agent.action_queue.append(result)
+
+
+async def _act_for_agent(agent, view, msg):
+    """Determine this tick's action for an agent under the 5s soft / 60s hard
+    timeout model. May queue future actions for subsequent ticks if the mind
+    returned a list. Falls back to last_action (or ACT_EAT noop) if the mind
+    is still in flight, raised, or returned None."""
+    if agent.action_queue:
+        action = agent.action_queue.popleft()
+        agent.last_action = action
+        return action
+
+    if agent.pending_task is not None and agent.pending_task.done():
+        try:
+            result = agent.pending_task.result()
+        except Exception:
+            result = None
+        agent.pending_task = None
+        _enqueue_actions(agent, result)
+        if agent.action_queue:
+            action = agent.action_queue.popleft()
+            agent.last_action = action
+            return action
+
+    if agent.pending_task is None:
+        agent.pending_task = asyncio.create_task(
+            _call_act(agent.act, view, msg)
+        )
+        try:
+            result = await asyncio.wait_for(
+                asyncio.shield(agent.pending_task), SOFT_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            # Still running; check again next tick.
+            pass
+        except Exception:
+            agent.pending_task = None
+        else:
+            agent.pending_task = None
+            _enqueue_actions(agent, result)
+            if agent.action_queue:
+                action = agent.action_queue.popleft()
+                agent.last_action = action
+                return action
+
+    return agent.last_action if agent.last_action is not None else Action(ACT_EAT)
 
 
 
@@ -155,6 +232,21 @@ class Game(object):
         if a.loaded:
             a.loaded = False
             self.terr.change(a.x, a.y, 1)
+        if a.pending_task is not None and not a.pending_task.done():
+            a.pending_task.cancel()
+        a.pending_task = None
+
+    async def _cancel_all_pending(self):
+        pending = [
+            a.pending_task for a in self.agent_population
+            if a.pending_task is not None and not a.pending_task.done()
+        ]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        for a in self.agent_population:
+            a.pending_task = None
 
     def move_agent(self, a, x, y):
         ''' Moves agent, a, to new position (x,y) unless difference in terrain levels between
@@ -165,7 +257,7 @@ class Game(object):
             a.x = x
             a.y = y
 
-    def run_agents(self):
+    async def run_agents(self):
         # Create a list containing the view for each agent in the population.
         views = []
         agent_map_get_small_view_fast = self.agent_map.get_small_view_fast
@@ -182,11 +274,14 @@ class Game(object):
             world_view = WV(a, agent_view, plant_view, terr_map, energy_map)
             views_append((a, world_view))
 
-        # Create a list containing the action for each agent, where each agent
-        # determines its actions based on its view of the world and messages 
-        # from its team.
+        # Determine each agent's action concurrently. Each call enforces the
+        # 5s soft / 60s hard timeout model (see _act_for_agent).
         messages = self.messages
-        actions = [(a, a.act(v, messages[a.team])) for (a, v) in views]
+        agents = [a for (a, _) in views]
+        acts = await asyncio.gather(
+            *[_act_for_agent(a, v, messages[a.team]) for (a, v) in views]
+        )
+        actions = list(zip(agents, acts))
         actions_dict = dict(actions)
         random.shuffle(actions)
 
@@ -300,8 +395,11 @@ class Game(object):
             self.winner = -1
 
         self.agent_map.unlock()
-        
-    def tick(self):
+
+        if self.winner is not None:
+            await self._cancel_all_pending()
+
+    async def tick(self):
         if not self.headless:
             scale = self.disp.scale
             for event in pygame.event.get():
@@ -328,7 +426,7 @@ class Game(object):
             pygame.event.pump()
             self.disp.flip()
 
-        self.run_agents()
+        await self.run_agents()
         self.run_plants()
         for msg in self.messages:
             msg.update()
@@ -458,7 +556,7 @@ TEAM_COLORS_FAST = [0xFF0000, 0xFFFFFF, 0xFF00FF, 0xFFFF00]
 
 class Agent(object):
     __slots__ = ['x', 'y', 'mind', 'energy', 'alive', 'team', 'loaded', 'color',
-                 'act']
+                 'act', 'action_queue', 'last_action', 'pending_task']
     def __init__(self, x, y, energy, team, AgentMind, cargs):
         self.x = x
         self.y = y
@@ -469,6 +567,9 @@ class Agent(object):
         self.loaded = False
         self.color = TEAM_COLORS_FAST[team % len(TEAM_COLORS_FAST)]
         self.act = self.mind.act
+        self.action_queue = collections.deque()
+        self.last_action = None
+        self.pending_task = None
     def __str__(self):
         return "Agent from team %i, energy %i" % (self.team,self.energy)
     def attack(self, other, offset = 0, contested = False):
@@ -746,11 +847,15 @@ def main(argv=None):
     return args, bounds, symmetric, mind_list
 
 
-if __name__ == "__main__":
-    args, bounds, symmetric, mind_list = main()
+async def _run_loop(args, bounds, symmetric, mind_list):
     while True:
         game = Game(bounds, mind_list, symmetric, args.max_time, headless=args.headless)
         while game.winner is None:
-            game.tick()
+            await game.tick()
         if args.headless:
             break
+
+
+if __name__ == "__main__":
+    args, bounds, symmetric, mind_list = main()
+    asyncio.run(_run_loop(args, bounds, symmetric, mind_list))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 Cython>=3.0
 pytest>=7
+pytest-asyncio>=0.23

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -1,0 +1,167 @@
+"""Tests for the asyncio engine (#18) — slow-mind fallback, pre-planned moves,
+sync mind compatibility, and cancellation."""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import asyncio
+
+import pytest
+
+import cells
+
+
+def _module(name, mind_cls):
+    class M:
+        pass
+
+    m = M()
+    m.AgentMind = mind_cls
+    m.name = name
+    return (name, m)
+
+
+class EatMind:
+    """Sync mind that just eats — verifies the sync path still works."""
+
+    def __init__(self, cargs):
+        pass
+
+    def act(self, view, msg):
+        return cells.Action(cells.ACT_EAT)
+
+
+async def test_sync_mind_compatibility():
+    """A sync `def act` mind runs unchanged under the async engine."""
+    g = cells.Game(
+        20,
+        [_module("a", EatMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=5,
+        headless=True,
+    )
+    while g.winner is None:
+        await g.tick()
+    assert g.winner is not None  # game terminated normally
+
+
+async def test_slow_mind_falls_back_to_last_action(monkeypatch):
+    """If a mind's act doesn't return within the soft timeout, the agent
+    advances using last_action and the next tick still works."""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class FirstFastThenSlow:
+        def __init__(self, cargs):
+            self.calls = 0
+
+        async def act(self, view, msg):
+            self.calls += 1
+            if self.calls == 1:
+                return cells.Action(cells.ACT_LIFT)
+            await asyncio.sleep(2.0)  # exceeds soft timeout
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("a", FirstFastThenSlow), _module("b", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    await g.tick()
+    team_zero = [a for a in g.agent_population if a.team == 0][0]
+    assert team_zero.last_action.type == cells.ACT_LIFT
+
+    # Tick 2: act spawns, hangs, times out, fallback to last_action.
+    # last_action is unchanged because the fallback path doesn't update it.
+    await g.tick()
+    assert team_zero.last_action.type == cells.ACT_LIFT
+
+    await g._cancel_all_pending()
+
+
+async def test_pre_planned_moves_consumed_in_order(monkeypatch):
+    """A mind returning a list of Actions has them consumed one-per-tick
+    without re-calling act."""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class BatchMind:
+        def __init__(self, cargs):
+            self.calls = 0
+
+        async def act(self, view, msg):
+            self.calls += 1
+            if self.calls == 1:
+                return [
+                    cells.Action(cells.ACT_LIFT),
+                    cells.Action(cells.ACT_DROP),
+                    cells.Action(cells.ACT_EAT),
+                ]
+            await asyncio.sleep(2.0)
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("a", BatchMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    team_zero = [a for a in g.agent_population if a.team == 0][0]
+
+    await g.tick()
+    assert team_zero.last_action.type == cells.ACT_LIFT
+
+    await g.tick()
+    assert team_zero.last_action.type == cells.ACT_DROP
+
+    await g.tick()
+    assert team_zero.last_action.type == cells.ACT_EAT
+
+    # Across all 3 ticks the mind was called exactly once.
+    assert team_zero.mind.calls == 1
+
+    await g._cancel_all_pending()
+
+
+async def test_pending_task_cancelled_on_game_end(monkeypatch):
+    """When the game ends, any in-flight pending_task is cancelled and the
+    underlying coroutine sees CancelledError."""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    cancelled = asyncio.Event()
+
+    class HangMind:
+        def __init__(self, cargs):
+            pass
+
+        async def act(self, view, msg):
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("a", HangMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    # Tick once to spawn the HangMind's act task; it times out and stays
+    # pending across the await.
+    await g.tick()
+    team_zero = [a for a in g.agent_population if a.team == 0][0]
+    assert team_zero.pending_task is not None
+
+    # End-of-game cleanup cancels the task and observes CancelledError.
+    await g._cancel_all_pending()
+    assert cancelled.is_set()
+    for a in g.agent_population:
+        assert a.pending_task is None

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -62,27 +62,27 @@ def test_display_update_and_flip_run(display_game):
     display_game.disp.flip()
 
 
-def test_space_key_resets_winner(display_game):
+async def test_space_key_resets_winner(display_game):
     pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_SPACE}))
-    display_game.tick()
+    await display_game.tick()
     assert display_game.winner == -1
 
 
-def test_e_key_toggles_show_energy(display_game):
+async def test_e_key_toggles_show_energy(display_game):
     initial = display_game.show_energy
     pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_e}))
-    display_game.tick()
+    await display_game.tick()
     assert display_game.show_energy != initial
 
 
-def test_a_key_toggles_show_agents(display_game):
+async def test_a_key_toggles_show_agents(display_game):
     initial = display_game.show_agents
     pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_a}))
-    display_game.tick()
+    await display_game.tick()
     assert display_game.show_agents != initial
 
 
-def test_left_click_uses_display_scale_for_lookup(display_game, capfd):
+async def test_left_click_uses_display_scale_for_lookup(display_game, capfd):
     """Click at scaled coords (10, 10) should look up cell (5, 5) given scale=2."""
     pygame.event.post(
         pygame.event.Event(
@@ -90,27 +90,27 @@ def test_left_click_uses_display_scale_for_lookup(display_game, capfd):
             {"button": 1, "pos": (10, 10)},
         )
     )
-    display_game.tick()
+    await display_game.tick()
     out, _ = capfd.readouterr()
     # Either prints "None" (empty cell) or "Agent from team ...".
     assert "None" in out or "Agent from team" in out
 
 
-def test_quit_key_q_calls_sys_exit(display_game):
+async def test_quit_key_q_calls_sys_exit(display_game):
     pygame.event.post(pygame.event.Event(pygame.KEYUP, {"key": pygame.K_q}))
     with pytest.raises(SystemExit):
-        display_game.tick()
+        await display_game.tick()
 
 
-def test_quit_event_calls_sys_exit(display_game):
+async def test_quit_event_calls_sys_exit(display_game):
     pygame.event.post(pygame.event.Event(pygame.QUIT))
     with pytest.raises(SystemExit):
-        display_game.tick()
+        await display_game.tick()
 
 
-def test_display_handles_many_ticks(display_game):
+async def test_display_handles_many_ticks(display_game):
     """Smoke test: 60 ticks triggers the team-population text refresh."""
     for _ in range(65):
         if display_game.winner is not None:
             break
-        display_game.tick()
+        await display_game.tick()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -61,7 +61,7 @@ def test_module_exports_legacy_api():
     assert hasattr(cells, "Game")
 
 
-def test_game_runs_to_draw_on_max_time():
+async def test_game_runs_to_draw_on_max_time():
     """Two stub minds that only eat will both survive until max_time."""
     _seed()
     g = cells.Game(
@@ -73,7 +73,7 @@ def test_game_runs_to_draw_on_max_time():
     )
     ticks = 0
     while g.winner is None and ticks < 500:
-        g.tick()
+        await g.tick()
         ticks += 1
     assert g.winner is not None
     assert g.winner == -1  # draw on max_time
@@ -94,7 +94,7 @@ class AttackEverythingMind:
         return cells.Action(cells.ACT_EAT)
 
 
-def test_attack_action_is_applied():
+async def test_attack_action_is_applied():
     """Place two attacking minds adjacent; one should kill the other."""
     _seed(2)
     g = cells.Game(
@@ -106,7 +106,7 @@ def test_attack_action_is_applied():
     )
     ticks = 0
     while g.winner is None and ticks < 500:
-        g.tick()
+        await g.tick()
         ticks += 1
     assert g.winner is not None
 
@@ -132,7 +132,7 @@ class CycleMind:
         return a
 
 
-def test_all_action_types_dispatch_without_crash():
+async def test_all_action_types_dispatch_without_crash():
     _seed(3)
     g = cells.Game(
         30,
@@ -143,6 +143,6 @@ def test_all_action_types_dispatch_without_crash():
     )
     ticks = 0
     while g.winner is None and ticks < 200:
-        g.tick()
+        await g.tick()
         ticks += 1
     assert ticks > 0

--- a/tests/test_minds.py
+++ b/tests/test_minds.py
@@ -44,7 +44,7 @@ def test_mind2_exposes_agent_mind():
     assert hasattr(m, "act")
 
 
-def test_mind1_vs_mind2_runs_to_termination(named_minds):
+async def test_mind1_vs_mind2_runs_to_termination(named_minds):
     """End-to-end headless game with the bundled minds."""
     _seed()
     m1, m2 = named_minds
@@ -57,13 +57,13 @@ def test_mind1_vs_mind2_runs_to_termination(named_minds):
     )
     ticks = 0
     while game.winner is None and ticks < 500:
-        game.tick()
+        await game.tick()
         ticks += 1
     assert game.winner is not None, "game did not terminate within tick budget"
     assert ticks > 0
 
 
-def test_mind1_self_play_runs(named_minds):
+async def test_mind1_self_play_runs(named_minds):
     """Self-play surfaces strategy bugs that asymmetric games hide."""
     _seed(7)
     m1, _ = named_minds
@@ -76,6 +76,6 @@ def test_mind1_self_play_runs(named_minds):
     )
     ticks = 0
     while game.winner is None and ticks < 300:
-        game.tick()
+        await game.tick()
         ticks += 1
     assert game.winner is not None

--- a/tournament.py
+++ b/tournament.py
@@ -7,6 +7,7 @@ draw). Writes scores.csv sorted by score descending.
 """
 
 import argparse
+import asyncio
 import configparser
 import random
 import sys
@@ -14,6 +15,13 @@ import sys
 import numpy
 
 from cells import Game, get_mind
+
+
+async def _play_game(bounds, pair, symmetric, max_time):
+    game = Game(bounds, pair, symmetric, max_time, headless=True)
+    while game.winner is None:
+        await game.tick()
+    return game.winner
 
 
 def _parse_cli(argv=None):
@@ -74,7 +82,7 @@ def _load_config(path="tournament.cfg"):
     return bounds, symmetric, [n.strip() for n in minds_str.split(",") if n.strip()]
 
 
-def main(argv=None):
+async def main_async(argv=None):
     args = _parse_cli(argv)
 
     if args.seed is not None:
@@ -98,14 +106,19 @@ def main(argv=None):
     ]
 
     for round_idx in range(args.rounds):
-        for pair in pairings:
-            game = Game(bounds, pair, symmetric, args.max_time, headless=True)
-            while game.winner is None:
-                game.tick()
-            if game.winner >= 0:
-                idx = mind_list.index(pair[game.winner])
-                scores[idx] += 3
-            elif game.winner == -1:
+        # Round-robin games within a round are independent — run them
+        # concurrently so a slow async mind in one pair doesn't stall
+        # the others. With sync minds this is effectively sequential.
+        winners = await asyncio.gather(
+            *[
+                _play_game(bounds, pair, symmetric, args.max_time)
+                for pair in pairings
+            ]
+        )
+        for pair, winner in zip(pairings, winners):
+            if winner >= 0:
+                scores[mind_list.index(pair[winner])] += 3
+            elif winner == -1:
                 scores[mind_list.index(pair[0])] += 1
                 scores[mind_list.index(pair[1])] += 1
             print(scores)
@@ -116,6 +129,10 @@ def main(argv=None):
     with open(args.output, "w") as f:
         for name, score in name_score:
             f.write("%s;%s\n" % (name, score))
+
+
+def main(argv=None):
+    asyncio.run(main_async(argv))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #18.

## Summary

Engine converted to asyncio with the 5s soft / 60s hard timeout model and per-agent action queues. Sync minds work unchanged — `inspect.isawaitable` decides per call. Display and pygame event handling stay sync inside the same coroutine per the spec.

### `cells.py`
- `Agent.__slots__` adds `action_queue` (deque), `last_action`, `pending_task`.
- `_call_act` invokes `mind.act` under `asyncio.timeout(60s)`, awaits if awaitable, returns otherwise.
- `_act_for_agent` is the per-tick decision: queue → harvest → spawn+wait(5s, shielded) → fallback to `last_action` (or `Action(ACT_EAT)` noop).
- `Game.run_agents` / `Game.tick` are now `async`. Per-tick acts gather concurrently so one slow team doesn't stall the others.
- `Game._cancel_all_pending()` runs after winner determination and from `del_agent`, so games don't leak in-flight tasks.
- `__main__` wraps the restart loop in `asyncio.run` via `_run_loop`.

### `tournament.py`
- `main_async` runs each round's pairings concurrently with `asyncio.gather`. Sync minds still effectively run sequentially in one event loop; network minds (future #19) will see real parallelism.
- `main()` wraps `main_async` in `asyncio.run` so the CLI entry stays sync.

### Test infrastructure
- `pytest.ini`: `asyncio_mode = auto` so `async def test_*` funcs are picked up without per-test decoration.
- `requirements-dev.txt`: add `pytest-asyncio>=0.23`.
- Existing `test_engine.py`, `test_minds.py`, `test_display.py` updated to `async def` + `await game.tick()`. `test_cli.py` (subprocess), `test_tournament.py` (subprocess), `test_terrain_generator.py`, `test_cython_helper.py` unchanged.

### New `tests/test_async_engine.py` (4 tests)
- **Sync mind compatibility** — `def act` mind plays a full game.
- **Slow mind falls back to last_action** — a mind that eventually hangs has the agent advance using its previous action; `last_action` is unchanged.
- **Pre-planned moves consumed in order** — returning a `list[Action]` queues them; the next 2 ticks consume without re-calling `act` (verified via the mind's call counter).
- **Cancellation** — `_cancel_all_pending` propagates `CancelledError` and zeroes `pending_task` on every agent.

## Test plan
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 36/36 in 4.8s.
- [x] `python cells.py mind1 mind2 --headless --max-time 30 --seed 1` runs to a winner.
- [x] `python tournament.py mind1 mind2 mind3 --rounds 1 --max-time 30 --seed 1` writes scores.csv with 3 rows.
- [x] Async tests use a monkeypatched 0.05s soft timeout so they run in ~30ms each, not the 5s default.

## Notes
- Forward-compat with #19 (server epic): `WorldView` still wraps live engine references — JSON serialization is in scope for #22, not here.
- Display rendering inside `Game.tick`'s coroutine accepts the spec tradeoff: a slow mind will stutter the FPS for up to 5s. `--headless` mode is unaffected.
- `asyncio.timeout` requires Python 3.11+; the CI matrix is 3.11/3.12 so this is fine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_