### PR TITLE
HTTP transport adapter (#20)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.24
 pygame>=2.5
+httpx>=0.27

--- a/tests/test_http_mind.py
+++ b/tests/test_http_mind.py
@@ -1,0 +1,166 @@
+"""Tests for the HTTP transport adapter (#20).
+
+Uses httpx.MockTransport to stand in for a contestant's bot server, so
+no actual sockets are opened. Covers:
+- Single-action response decoded into an Action.
+- Pre-planned-moves response queues a list of Actions.
+- Malformed responses fall back to None (engine -> last_action).
+- HTTP errors fall back to None.
+- A full game can be played with one HttpMind opponent.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import json
+
+import httpx
+import pytest
+
+import cells
+from transports.http_mind import HttpMind
+
+
+def _make_mind(handler, name="bot"):
+    transport = httpx.MockTransport(handler)
+    return HttpMind(name, "http://test.invalid/act", transport=transport)
+
+
+class _StubAgent:
+    def __init__(self, x=5, y=5, team=0, energy=20, loaded=False):
+        self.x, self.y, self.team, self.energy, self.loaded = x, y, team, energy, loaded
+
+    def get_pos(self):
+        return (self.x, self.y)
+
+    def get_team(self):
+        return self.team
+
+
+def _make_view():
+    terr = cells.ScalarMapLayer((10, 10))
+    energy = cells.ScalarMapLayer((10, 10))
+    me = _StubAgent()
+    return cells.WorldView(me, [], [], terr, energy, tick=1)
+
+
+async def test_single_action_response():
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"type": 2})
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), [])
+    assert isinstance(action, cells.Action)
+    assert action.type == cells.ACT_EAT
+    # Verify the request body has the snapshot schema.
+    assert "view" in captured["body"]
+    assert "messages" in captured["body"]
+    assert captured["body"]["view"]["me"]["pos"] == [5, 5]
+    await mind.aclose()
+
+
+async def test_action_with_data_field():
+    def handler(request):
+        return httpx.Response(200, json={"type": 1, "data": [3, 4]})
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), [])
+    assert action.type == cells.ACT_MOVE
+    assert action.get_data() == [3, 4]
+    await mind.aclose()
+
+
+async def test_pre_planned_moves_response():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "actions": [
+                    {"type": 1, "data": [3, 4]},
+                    {"type": 2},
+                ]
+            },
+        )
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    actions = await agent.act(_make_view(), [])
+    assert isinstance(actions, list)
+    assert len(actions) == 2
+    assert actions[0].type == cells.ACT_MOVE
+    assert actions[0].get_data() == [3, 4]
+    assert actions[1].type == cells.ACT_EAT
+    await mind.aclose()
+
+
+async def test_malformed_response_returns_none():
+    """Non-JSON or missing 'type' falls back to None."""
+    def handler(request):
+        return httpx.Response(200, text="not json at all")
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_5xx_response_returns_none():
+    def handler(request):
+        return httpx.Response(500, text="upstream error")
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_response_missing_type_returns_none():
+    def handler(request):
+        return httpx.Response(200, json={"foo": "bar"})
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_http_mind_plays_a_full_game():
+    """End-to-end: an HttpMind opponent runs through the engine without
+    errors. The remote bot just eats every tick."""
+    def handler(request):
+        return httpx.Response(200, json={"type": cells.ACT_EAT})
+
+    http_bot = _make_mind(handler, name="http_bot")
+
+    # Build a sync mind module for the other team.
+    class _Local:
+        class AgentMind:
+            def __init__(self, cargs):
+                pass
+
+            def act(self, view, msg):
+                return cells.Action(cells.ACT_EAT)
+
+    local = _Local()
+    local.name = "local"
+
+    g = cells.Game(
+        20,
+        [(http_bot.name, http_bot), (local.name, local)],
+        symmetric=True,
+        max_time=5,
+        headless=True,
+    )
+    while g.winner is None:
+        await g.tick()
+    assert g.winner is not None
+    await http_bot.aclose()

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,0 +1,10 @@
+"""Transport adapters that route the engine's `act()` calls to bots
+running outside the engine process. Each adapter implements the
+AgentMind interface but its `act` is async and makes a network call.
+
+See cells-server epic (#19) for the architecture overview.
+"""
+
+from transports.http_mind import HttpMind
+
+__all__ = ["HttpMind"]

--- a/transports/http_mind.py
+++ b/transports/http_mind.py
@@ -1,0 +1,106 @@
+"""HTTP transport for cells bots.
+
+HttpMind wraps an HTTP endpoint as a mind module — the engine sees a
+mind_list entry shaped like (name, module_with_AgentMind), and each
+tick the mind's act() POSTs the WorldView snapshot to the contestant's
+URL and parses the action(s) from the response.
+
+Wire format (request):
+    POST <url>
+    {
+      "view": <WorldView.to_json() output>,
+      "messages": ["string", ...]
+    }
+
+Wire format (response — single action):
+    {"type": <int>, "data": [...]}    # data is optional
+
+Wire format (response — pre-planned moves):
+    {"actions": [{"type": <int>, "data": [...]}, ...]}
+
+A bot that times out, returns malformed JSON, or returns 5xx is treated
+the same way as a local mind that raised: the engine falls back to
+last_action and the strike will be counted by the DQ layer (#25).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+import cells
+
+
+def _parse_single(d: Any):
+    if not isinstance(d, dict):
+        return None
+    action_type = d.get("type")
+    if action_type is None:
+        return None
+    data = d.get("data")
+    return cells.Action(int(action_type), data)
+
+
+def _parse_action(payload: Any):
+    """Decode an HTTP response body into an Action or list[Action].
+
+    Returns None if the payload is malformed; the caller treats None the
+    same as a mind exception (fall back to last_action)."""
+    if payload is None:
+        return None
+    if isinstance(payload, dict):
+        if "actions" in payload:
+            return [a for a in (_parse_single(x) for x in payload["actions"]) if a is not None]
+        return _parse_single(payload)
+    return None
+
+
+class HttpMind:
+    """A mind backed by an HTTP endpoint. Acts as a mind module from the
+    engine's perspective: exposes `name` and `AgentMind`.
+
+    All agents on the same team share a single HTTP client.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        *,
+        headers: dict | None = None,
+        timeout: float = 5.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ):
+        self.name = name
+        self._url = url
+        self._headers = headers or {}
+        self._timeout = timeout
+        self._client = httpx.AsyncClient(timeout=timeout, transport=transport)
+
+        outer = self
+
+        class _AgentMind:
+            def __init__(self, cargs):
+                self._http = outer
+
+            async def act(self, view, msg):
+                return await outer._call(view, msg)
+
+        self.AgentMind = _AgentMind
+
+    async def _call(self, view, msg):
+        payload = {
+            "view": view.to_json(),
+            "messages": list(msg),
+        }
+        try:
+            r = await self._client.post(self._url, json=payload, headers=self._headers)
+            r.raise_for_status()
+            return _parse_action(r.json())
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+            return None
+
+    async def aclose(self):
+        await self._client.aclose()


### PR DESCRIPTION
Closes #20.

## Summary

Add `transports/http_mind.py`: `HttpMind` wraps a contestant URL as a mind module. The engine sees a `mind_list` entry shaped like `(name, module_with_AgentMind)`, and each tick the agent's `act()` POSTs the `WorldView.to_json()` snapshot (#22) to the URL and parses the response.

### Wire format
- Request: `{"view": <to_json output>, "messages": [...]}`
- Response (single): `{"type": int, "data": [...]}` (data optional)
- Response (pre-planned): `{"actions": [{"type": int, "data": [...]}, ...]}`

A bot that times out, returns malformed JSON, or returns 5xx is treated the same way as a local mind that raised: `act()` returns `None`, the engine falls back to `last_action`, and the eventual DQ layer (#25) will count strikes.

All agents on the same team share a single `httpx.AsyncClient`. The optional `transport=` kwarg lets tests inject `httpx.MockTransport` to fake the server without opening real sockets.

`requirements.txt`: add `httpx>=0.27`.

## Test plan
- [x] `tests/test_http_mind.py` (7 tests): single-action, action+data, pre-planned moves, malformed non-JSON, 5xx, missing `type` field, end-to-end full game.
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 50/50 in 5s.

## Notes
- `HttpMind` itself plays the role of a mind *module* (with `name` + `AgentMind`), not a mind class. This keeps the engine's mind_list contract unchanged.
- The 5s soft timeout is enforced by the engine (#18); `HttpMind.timeout` is the per-request httpx client timeout, default 5s, configured to match.
- Future work: `act_batch` for one POST per team per tick lives in #23.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_