### PR TITLE
MCP transport adapter (#21)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.24
 pygame>=2.5
 httpx>=0.27
+mcp>=1.0

--- a/tests/test_mcp_mind.py
+++ b/tests/test_mcp_mind.py
@@ -1,0 +1,157 @@
+"""Tests for the MCP transport adapter (#21).
+
+McpMind has the same wire format as HttpMind — only the transport
+differs. Tests inject a fake MCP session via the `session=` kwarg so we
+don't need to spin up a stdio subprocess or an SSE server.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import json
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+import cells
+from transports.mcp_mind import McpMind
+
+
+class FakeSession:
+    def __init__(self, *, structured=None, text=None, is_error=False, raises=None):
+        self.calls = []
+        self._structured = structured
+        self._text = text
+        self._is_error = is_error
+        self._raises = raises
+
+    async def call_tool(self, name, arguments=None, **kwargs):
+        self.calls.append((name, arguments))
+        if self._raises is not None:
+            raise self._raises
+        content = []
+        if self._text is not None:
+            content.append(TextContent(type="text", text=self._text))
+        return CallToolResult(
+            content=content,
+            structuredContent=self._structured,
+            isError=self._is_error,
+        )
+
+
+class _StubAgent:
+    def __init__(self, x=5, y=5, team=0, energy=20, loaded=False):
+        self.x, self.y, self.team, self.energy, self.loaded = x, y, team, energy, loaded
+
+    def get_pos(self):
+        return (self.x, self.y)
+
+    def get_team(self):
+        return self.team
+
+
+def _make_view():
+    terr = cells.ScalarMapLayer((10, 10))
+    energy = cells.ScalarMapLayer((10, 10))
+    return cells.WorldView(_StubAgent(), [], [], terr, energy, tick=1)
+
+
+async def test_structured_content_action():
+    session = FakeSession(structured={"type": 2})
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), [])
+    assert action.type == cells.ACT_EAT
+    # Verify the call_tool args carry the snapshot.
+    assert session.calls[0][0] == "act"
+    assert session.calls[0][1]["view"]["me"]["pos"] == [5, 5]
+    assert session.calls[0][1]["messages"] == []
+
+
+async def test_text_content_action():
+    session = FakeSession(text=json.dumps({"type": 1, "data": [3, 4]}))
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), [])
+    assert action.type == cells.ACT_MOVE
+    assert action.get_data() == [3, 4]
+
+
+async def test_pre_planned_moves_via_structured():
+    session = FakeSession(
+        structured={
+            "actions": [
+                {"type": 1, "data": [3, 4]},
+                {"type": 2},
+            ]
+        }
+    )
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    actions = await agent.act(_make_view(), [])
+    assert len(actions) == 2
+    assert actions[0].type == cells.ACT_MOVE
+    assert actions[1].type == cells.ACT_EAT
+
+
+async def test_is_error_returns_none():
+    session = FakeSession(structured={"type": 2}, is_error=True)
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+
+
+async def test_call_tool_raises_returns_none():
+    session = FakeSession(raises=RuntimeError("connection dropped"))
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+
+
+async def test_text_content_malformed_returns_none():
+    session = FakeSession(text="not json at all")
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+
+
+async def test_mcp_mind_plays_a_full_game():
+    session = FakeSession(structured={"type": cells.ACT_EAT})
+    mcp_bot = McpMind("mcp_bot", session=session)
+
+    class _Local:
+        class AgentMind:
+            def __init__(self, cargs):
+                pass
+
+            def act(self, view, msg):
+                return cells.Action(cells.ACT_EAT)
+
+    local = _Local()
+    local.name = "local"
+
+    g = cells.Game(
+        20,
+        [(mcp_bot.name, mcp_bot), (local.name, local)],
+        symmetric=True,
+        max_time=5,
+        headless=True,
+    )
+    while g.winner is None:
+        await g.tick()
+    assert g.winner is not None
+
+
+def test_constructor_requires_one_transport():
+    with pytest.raises(ValueError):
+        McpMind("bot")
+    with pytest.raises(ValueError):
+        McpMind(
+            "bot",
+            server_command=["python", "x.py"],
+            server_url="http://example/sse",
+        )

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -6,5 +6,6 @@ See cells-server epic (#19) for the architecture overview.
 """
 
 from transports.http_mind import HttpMind
+from transports.mcp_mind import McpMind
 
-__all__ = ["HttpMind"]
+__all__ = ["HttpMind", "McpMind"]

--- a/transports/mcp_mind.py
+++ b/transports/mcp_mind.py
@@ -1,0 +1,128 @@
+"""MCP transport for cells bots.
+
+McpMind wraps a contestant's MCP server as a mind module. The server is
+expected to expose an `act` tool that accepts {view, messages} and
+returns the same wire format as HttpMind (#20):
+
+  Single action:        {"type": int, "data": [...]}
+  Pre-planned moves:    {"actions": [{"type": ..., "data": ...}, ...]}
+
+The result can be carried in either the structuredContent field of the
+CallToolResult (preferred) or as JSON text in a TextContent block.
+
+Two transports are supported:
+  - stdio:  pass server_command=["python", "bot_server.py"]
+  - SSE:    pass server_url="http://bot.example.com/mcp/sse"
+
+Errors (connection drop, malformed payload, server-reported error) are
+swallowed: act() returns None and the engine falls back to last_action.
+The DQ layer (#25) is responsible for counting strikes.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import AsyncExitStack
+from typing import Any
+
+from transports.http_mind import _parse_action
+
+import cells
+
+
+def _parse_result(result) -> Any:
+    """Parse an MCP CallToolResult into Action(s) or None."""
+    if getattr(result, "isError", False):
+        return None
+    structured = getattr(result, "structuredContent", None)
+    if structured:
+        return _parse_action(structured)
+    content = getattr(result, "content", None) or []
+    for item in content:
+        text = getattr(item, "text", None)
+        if text is None:
+            continue
+        try:
+            return _parse_action(json.loads(text))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+class McpMind:
+    """A mind backed by an MCP server. Acts as a mind module from the
+    engine's perspective: exposes `name` and `AgentMind`.
+
+    All agents on the same team share a single MCP session.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        server_command: list[str] | None = None,
+        server_url: str | None = None,
+        session=None,
+    ):
+        if (server_command is None) == (server_url is None) and session is None:
+            raise ValueError(
+                "McpMind needs exactly one of server_command, server_url, or session"
+            )
+        self.name = name
+        self._server_command = server_command
+        self._server_url = server_url
+        self._session = session
+        self._stack: AsyncExitStack | None = None
+
+        outer = self
+
+        class _AgentMind:
+            def __init__(self, cargs):
+                self._mcp = outer
+
+            async def act(self, view, msg):
+                return await outer._call(view, msg)
+
+        self.AgentMind = _AgentMind
+
+    async def _ensure_session(self):
+        if self._session is not None:
+            return
+        from mcp import ClientSession
+        from mcp.client.stdio import StdioServerParameters, stdio_client
+
+        self._stack = AsyncExitStack()
+        if self._server_command is not None:
+            params = StdioServerParameters(
+                command=self._server_command[0],
+                args=list(self._server_command[1:]),
+            )
+            read, write = await self._stack.enter_async_context(stdio_client(params))
+        else:
+            from mcp.client.sse import sse_client
+
+            read, write = await self._stack.enter_async_context(
+                sse_client(self._server_url)
+            )
+
+        self._session = await self._stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await self._session.initialize()
+
+    async def _call(self, view, msg):
+        try:
+            await self._ensure_session()
+            result = await self._session.call_tool(
+                "act",
+                arguments={"view": view.to_json(), "messages": list(msg)},
+            )
+            return _parse_result(result)
+        except Exception:
+            return None
+
+    async def aclose(self):
+        if self._stack is not None:
+            await self._stack.aclose()
+            self._stack = None
+        self._session = None


### PR DESCRIPTION
Closes #21.

## Summary

Add `transports/mcp_mind.py`: `McpMind` wraps a contestant's MCP server as a mind module. The bot's MCP server is expected to expose an `act` tool that accepts `{view, messages}` and returns the same wire format as `HttpMind` (#20):

- Single action: `{"type": int, "data": [...]}`
- Pre-planned moves: `{"actions": [{"type": ..., "data": ...}, ...]}`

Result can be carried in either `structuredContent` (preferred) or as JSON text in a `TextContent` block of the `CallToolResult`.

### Transports
- **stdio:** `McpMind("bot", server_command=["python", "bot_server.py"])`
- **SSE:** `McpMind("bot", server_url="http://bot.example.com/mcp/sse")`

Errors (connection drop, malformed payload, `isError`) are swallowed: `act()` returns `None` and the engine falls back to `last_action`. The DQ layer (#25) will count strikes.

### Test injection point

The constructor accepts a `session=` kwarg so tests can inject a fake `ClientSession` rather than spawn a stdio subprocess. `test_mcp_mind.py` uses a `FakeSession` exposing the same `call_tool` surface as the real `mcp.ClientSession`.

`requirements.txt`: add `mcp>=1.0`.

## Test plan
- [x] `tests/test_mcp_mind.py` (8 tests): structured action, text action, pre-planned moves, isError, raise → None, malformed text → None, full game, constructor validation.
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 58/58 in 6s.

## Notes
- The `McpMind` class itself plays the role of a mind *module* (with `name` + `AgentMind`), matching the `HttpMind` pattern from #20.
- Live stdio/SSE transport tests would require shipping a fixture MCP server; deferred until needed in CI.
- `act_batch` for one tool call per team per tick lives in #23.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_