### PR TITLE
Disqualify bots after N strikes (#25)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -53,48 +53,79 @@ def _enqueue_actions(agent, result):
         agent.action_queue.append(result)
 
 
-async def _act_for_agent(agent, view, msg):
+async def _act_for_agent(agent, view, msg, *, is_disqualified=False, on_strike=None):
     """Determine this tick's action for an agent under the 5s soft / 60s hard
     timeout model. May queue future actions for subsequent ticks if the mind
     returned a list. Falls back to last_action (or ACT_EAT noop) if the mind
-    is still in flight, raised, or returned None."""
+    is still in flight, raised, or returned None.
+
+    If `is_disqualified` is True, the agent NOOPs unconditionally — its
+    team has burned through too many strikes (see #25).
+
+    `on_strike(reason)` is invoked once per fallback event so the caller
+    can count strikes. Reasons: 'soft_timeout', 'hard_timeout',
+    'exception', 'malformed'.
+    """
+    if is_disqualified:
+        return Action(ACT_EAT)
+
     if agent.action_queue:
         action = agent.action_queue.popleft()
         agent.last_action = action
         return action
 
+    fresh = None
+    fresh_reason = None
+
     if agent.pending_task is not None and agent.pending_task.done():
         try:
-            result = agent.pending_task.result()
+            fresh = agent.pending_task.result()
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            fresh_reason = "hard_timeout"
         except Exception:
-            result = None
+            fresh_reason = "exception"
         agent.pending_task = None
-        _enqueue_actions(agent, result)
+        if fresh is None and fresh_reason is None:
+            fresh_reason = "malformed"
+
+    if fresh is None and agent.pending_task is None:
+        agent.pending_task = asyncio.create_task(
+            _call_act(agent.act, view, msg)
+        )
+        try:
+            fresh = await asyncio.wait_for(
+                asyncio.shield(agent.pending_task), SOFT_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            fresh_reason = "soft_timeout"
+        except asyncio.CancelledError:
+            fresh_reason = "hard_timeout"
+            agent.pending_task = None
+        except Exception:
+            fresh_reason = "exception"
+            agent.pending_task = None
+        else:
+            agent.pending_task = None
+            if fresh is None:
+                fresh_reason = "malformed"
+
+    if fresh is not None:
+        _enqueue_actions(agent, fresh)
         if agent.action_queue:
             action = agent.action_queue.popleft()
             agent.last_action = action
             return action
 
-    if agent.pending_task is None:
-        agent.pending_task = asyncio.create_task(
-            _call_act(agent.act, view, msg)
-        )
-        try:
-            result = await asyncio.wait_for(
-                asyncio.shield(agent.pending_task), SOFT_TIMEOUT_SECONDS
-            )
-        except asyncio.TimeoutError:
-            # Still running; check again next tick.
-            pass
-        except Exception:
-            agent.pending_task = None
-        else:
-            agent.pending_task = None
-            _enqueue_actions(agent, result)
-            if agent.action_queue:
-                action = agent.action_queue.popleft()
-                agent.last_action = action
-                return action
+    # If we still have nothing fresh and a task is in flight from a prior
+    # tick, the bot is keeping us in fall-back territory — count a soft
+    # strike for this tick. Without this, a permanently hung bot would
+    # only ever accumulate one strike (on the tick the call was first
+    # spawned) and never trip the DQ threshold.
+    if fresh is None and fresh_reason is None and agent.pending_task is not None:
+        fresh_reason = "soft_timeout"
+
+    if fresh_reason is not None and on_strike is not None:
+        on_strike(fresh_reason)
 
     return agent.last_action if agent.last_action is not None else Action(ACT_EAT)
 
@@ -144,7 +175,7 @@ def get_next_move(old_x, old_y, x, y):
 
 class Game(object):
     ''' Represents a game between different minds. '''
-    def __init__(self, bounds, mind_list, symmetric, max_time, headless = False):
+    def __init__(self, bounds, mind_list, symmetric, max_time, headless=False, strike_threshold=3):
         self.size = self.width, self.height = (bounds, bounds)
         self.mind_list = mind_list
         self.messages = [MessageQueue() for x in mind_list]
@@ -154,6 +185,10 @@ class Game(object):
         self.time = 0
         self.clock = pygame.time.Clock()
         self.max_time = max_time
+        self.strike_threshold = strike_threshold
+        self.strikes = [0 for _ in mind_list]
+        self.disqualified = set()
+        self.strike_log = []  # (tick, team, reason, count)
         self.tic = time.time()
         self.terr = ScalarMapLayer(self.size)
         self.terr.set_perlin(10, symmetric)
@@ -248,6 +283,13 @@ class Game(object):
         for a in self.agent_population:
             a.pending_task = None
 
+    def _record_strike(self, team, reason):
+        self.strikes[team] += 1
+        self.strike_log.append((self.time, team, reason, self.strikes[team]))
+        if self.strikes[team] >= self.strike_threshold and team not in self.disqualified:
+            self.disqualified.add(team)
+            self.strike_log.append((self.time, team, "DISQUALIFIED", self.strikes[team]))
+
     def move_agent(self, a, x, y):
         ''' Moves agent, a, to new position (x,y) unless difference in terrain levels between
         its current position and new position is greater than 4.'''
@@ -275,11 +317,21 @@ class Game(object):
             views_append((a, world_view))
 
         # Determine each agent's action concurrently. Each call enforces the
-        # 5s soft / 60s hard timeout model (see _act_for_agent).
+        # 5s soft / 60s hard timeout model (see _act_for_agent), records a
+        # strike on every fallback, and NOOPs if the team is disqualified.
         messages = self.messages
         agents = [a for (a, _) in views]
         acts = await asyncio.gather(
-            *[_act_for_agent(a, v, messages[a.team]) for (a, v) in views]
+            *[
+                _act_for_agent(
+                    a,
+                    v,
+                    messages[a.team],
+                    is_disqualified=(a.team in self.disqualified),
+                    on_strike=(lambda reason, team=a.team: self._record_strike(team, reason)),
+                )
+                for (a, v) in views
+            ]
         )
         actions = list(zip(agents, acts))
         actions_dict = dict(actions)

--- a/tests/test_strikes.py
+++ b/tests/test_strikes.py
@@ -1,0 +1,190 @@
+"""Tests for the disqualify-on-N-strikes layer (#25).
+
+A misbehaving bot (timeout, exception, malformed) accrues strikes; once
+the threshold is hit the team is marked disqualified and its agents
+NOOP for the rest of the game. The tournament keeps running.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import asyncio
+
+import pytest
+
+import cells
+
+
+def _module(name, mind_cls):
+    class M:
+        pass
+
+    m = M()
+    m.AgentMind = mind_cls
+    m.name = name
+    return (name, m)
+
+
+class EatMind:
+    def __init__(self, cargs):
+        pass
+
+    def act(self, view, msg):
+        return cells.Action(cells.ACT_EAT)
+
+
+async def test_timeout_strike_increments(monkeypatch):
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class HangMind:
+        def __init__(self, cargs):
+            pass
+
+        async def act(self, view, msg):
+            await asyncio.sleep(2.0)
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("hang", HangMind), _module("eat", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+    await g.tick()
+    assert g.strikes[0] >= 1
+    assert g.strike_log[0][2] == "soft_timeout"
+    await g._cancel_all_pending()
+
+
+async def test_disqualified_after_threshold(monkeypatch):
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class RaiseMind:
+        def __init__(self, cargs):
+            pass
+
+        async def act(self, view, msg):
+            raise RuntimeError("boom")
+
+    g = cells.Game(
+        20,
+        [_module("raise", RaiseMind), _module("eat", EatMind)],
+        symmetric=True,
+        max_time=50,
+        headless=True,
+        strike_threshold=3,
+    )
+
+    for _ in range(5):
+        if 0 in g.disqualified:
+            break
+        await g.tick()
+
+    assert 0 in g.disqualified
+    assert g.strikes[0] >= 3
+    # DISQUALIFIED entry recorded.
+    reasons = [entry[2] for entry in g.strike_log]
+    assert "DISQUALIFIED" in reasons
+    await g._cancel_all_pending()
+
+
+async def test_disqualified_team_agents_noop(monkeypatch):
+    """Once DQ'd, the agent's act is no longer called even if it would hang."""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class CountingHangMind:
+        def __init__(self, cargs):
+            self.calls = 0
+
+        async def act(self, view, msg):
+            self.calls += 1
+            await asyncio.sleep(2.0)
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("hang", CountingHangMind), _module("eat", EatMind)],
+        symmetric=True,
+        max_time=50,
+        headless=True,
+        strike_threshold=2,
+    )
+
+    # Tick until DQ.
+    for _ in range(5):
+        if 0 in g.disqualified:
+            break
+        await g.tick()
+    assert 0 in g.disqualified
+
+    team_zero = [a for a in g.agent_population if a.team == 0][0]
+    calls_at_dq = team_zero.mind.calls
+
+    # Subsequent ticks should not invoke act.
+    for _ in range(3):
+        await g.tick()
+    assert team_zero.mind.calls == calls_at_dq
+    await g._cancel_all_pending()
+
+
+async def test_recovering_mind_under_generous_threshold(monkeypatch):
+    """A mind that times out a few times but eventually succeeds should not
+    be DQ'd when the threshold is generous. (With threshold=3 and a 0.05s
+    soft timeout, even a brief sleep accumulates strikes — that's the
+    expected aggressive behavior, not a bug. Real games use 5s soft
+    and threshold 3.)"""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class EventuallyFastMind:
+        def __init__(self, cargs):
+            self.calls = 0
+
+        async def act(self, view, msg):
+            self.calls += 1
+            if self.calls == 1:
+                await asyncio.sleep(0.1)  # may produce 1-2 strikes
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        20,
+        [_module("flaky", EventuallyFastMind), _module("eat", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=20,
+    )
+
+    for _ in range(8):
+        await g.tick()
+
+    assert 0 not in g.disqualified
+    await g._cancel_all_pending()
+
+
+async def test_strike_log_records_tick_and_reason(monkeypatch):
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    class NoneMind:
+        """A mind that returns None — counts as 'malformed'."""
+
+        def __init__(self, cargs):
+            pass
+
+        def act(self, view, msg):
+            return None
+
+    g = cells.Game(
+        20,
+        [_module("none", NoneMind), _module("eat", EatMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=2,
+    )
+    await g.tick()
+    assert any(entry[2] == "malformed" for entry in g.strike_log)
+    # tick is the engine's self.time at the moment of the strike (0 on
+    # the first tick before the increment).
+    assert all(isinstance(entry[0], int) for entry in g.strike_log)


### PR DESCRIPTION
Closes #25.

## Summary

Engine-side resilience layer: a misbehaving bot accrues strikes per game; once the threshold is hit (default 3) the team is marked disqualified and its agents NOOP for the remainder. Other teams keep playing normally.

### Strike sources
- `soft_timeout` — `wait_for(5s)` elapsed, task still in flight
- `hard_timeout` — task cancelled or exceeded 60s ceiling
- `exception` — `mind.act` raised
- `malformed` — `mind.act` returned `None`

A strike is recorded once per tick whenever the agent falls back to `last_action`. If the prior tick's pending task is still in flight at the start of this tick, that also counts as a `soft_timeout` strike — without this, a permanently hung bot would only accumulate one strike (on the tick the call was first spawned) and never trip the threshold.

### Game additions
```python
self.strike_threshold = strike_threshold  # configurable, default 3
self.strikes = [0, 0, ...]                # per-team
self.disqualified = set()                 # team indices over threshold
self.strike_log = []                      # (tick, team, reason, count)
```

Once a team is in `self.disqualified`, `_act_for_agent` short-circuits and returns `Action(ACT_EAT)` without spawning or awaiting anything.

## Test plan
- [x] `tests/test_strikes.py` (5 tests): soft_timeout increment, 3 exceptions → DQ'd, DQ'd team's `act` is not called again, generous threshold accommodates flaky bot, strike_log entries shape.
- [x] `SDL_VIDEODRIVER=dummy python -m pytest -v` → 63/63 in 6s.

## Notes
- `strike_log` is in-memory; tournament-level `tournament.log` writing is deferred to whenever the bot config epic (#24) lands.
- Per-bot strike threshold (vs per-game) is also a future enhancement once we have stable bot identifiers from #24.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuJuck6GdePi1usqiCA3gA)_