### PR TITLE
Per-team batch protocol for network minds (#23)

### DIFF
--- a/cells.py
+++ b/cells.py
@@ -299,6 +299,81 @@ class Game(object):
             a.x = x
             a.y = y
 
+    async def _dispatch_team(self, team, agent_views):
+        """Resolve this tick's action for every agent on `team`. Uses the
+        per-team batch protocol (#23) if the team's mind module exposes
+        `act_batch`; otherwise falls back to the per-agent path that
+        carries the #18 soft/hard timeout model."""
+        is_dq = team in self.disqualified
+        mind_module = self.mind_list[team][1]
+        if not is_dq and hasattr(mind_module, "act_batch"):
+            return await self._dispatch_team_batch(team, mind_module, agent_views)
+        return await asyncio.gather(*[
+            _act_for_agent(
+                a, v, self.messages[team],
+                is_disqualified=is_dq,
+                on_strike=(lambda reason, t=team: self._record_strike(t, reason)),
+            )
+            for (a, v) in agent_views
+        ])
+
+    async def _dispatch_team_batch(self, team, mind_module, agent_views):
+        """One batch call per team per tick. Agents with pre-planned moves
+        from a prior tick consume their queue first; only the rest are
+        sent. Missing entries in the response strike the team and fall
+        back to last_action — matching the per-agent semantics."""
+        results = [None] * len(agent_views)
+        for i, (a, _) in enumerate(agent_views):
+            if a.action_queue:
+                action = a.action_queue.popleft()
+                a.last_action = action
+                results[i] = action
+
+        pending_idx = [i for i in range(len(agent_views)) if results[i] is None]
+        if not pending_idx:
+            return results
+
+        batch_input = [(agent_views[i][0].id, agent_views[i][1]) for i in pending_idx]
+        msg = self.messages[team]
+
+        raw = None
+        reason = None
+        try:
+            raw = await asyncio.wait_for(
+                mind_module.act_batch(batch_input, msg),
+                SOFT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            reason = "soft_timeout"
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            reason = "exception"
+
+        if not isinstance(raw, dict):
+            raw = {}
+
+        for i in pending_idx:
+            a = agent_views[i][0]
+            agent_result = raw.get(a.id)
+            if agent_result is None:
+                self._record_strike(team, reason or "malformed")
+                fallback = a.last_action if a.last_action is not None else Action(ACT_EAT)
+                results[i] = fallback
+            elif isinstance(agent_result, list):
+                if not agent_result:
+                    self._record_strike(team, "malformed")
+                    fallback = a.last_action if a.last_action is not None else Action(ACT_EAT)
+                    results[i] = fallback
+                else:
+                    a.action_queue.extend(agent_result[1:])
+                    a.last_action = agent_result[0]
+                    results[i] = agent_result[0]
+            else:
+                a.last_action = agent_result
+                results[i] = agent_result
+        return results
+
     async def run_agents(self):
         # Create a list containing the view for each agent in the population.
         views = []
@@ -316,23 +391,23 @@ class Game(object):
             world_view = WV(a, agent_view, plant_view, terr_map, energy_map, self.time)
             views_append((a, world_view))
 
-        # Determine each agent's action concurrently. Each call enforces the
-        # 5s soft / 60s hard timeout model (see _act_for_agent), records a
-        # strike on every fallback, and NOOPs if the team is disqualified.
-        messages = self.messages
-        agents = [a for (a, _) in views]
-        acts = await asyncio.gather(
-            *[
-                _act_for_agent(
-                    a,
-                    v,
-                    messages[a.team],
-                    is_disqualified=(a.team in self.disqualified),
-                    on_strike=(lambda reason, team=a.team: self._record_strike(team, reason)),
-                )
-                for (a, v) in views
-            ]
+        # Group views by team and dispatch one team at a time (#23). If the
+        # team's mind exposes act_batch, the team's agents share a single
+        # call per tick; otherwise the engine falls back to per-agent
+        # dispatch (preserving the soft/hard timeout model from #18).
+        by_team = collections.defaultdict(list)
+        for (a, v) in views:
+            by_team[a.team].append((a, v))
+        team_ids = sorted(by_team.keys())
+        per_team_results = await asyncio.gather(
+            *[self._dispatch_team(t, by_team[t]) for t in team_ids]
         )
+        acts_by_agent = {}
+        for tid, results in zip(team_ids, per_team_results):
+            for (a, _), action in zip(by_team[tid], results):
+                acts_by_agent[a] = action
+        agents = [a for (a, _) in views]
+        acts = [acts_by_agent[a] for a in agents]
         actions = list(zip(agents, acts))
         actions_dict = dict(actions)
         random.shuffle(actions)
@@ -608,7 +683,8 @@ TEAM_COLORS_FAST = [0xFF0000, 0xFFFFFF, 0xFF00FF, 0xFFFF00]
 
 class Agent(object):
     __slots__ = ['x', 'y', 'mind', 'energy', 'alive', 'team', 'loaded', 'color',
-                 'act', 'action_queue', 'last_action', 'pending_task']
+                 'act', 'action_queue', 'last_action', 'pending_task', 'id']
+    _next_id = 0
     def __init__(self, x, y, energy, team, AgentMind, cargs):
         self.x = x
         self.y = y
@@ -622,6 +698,8 @@ class Agent(object):
         self.action_queue = collections.deque()
         self.last_action = None
         self.pending_task = None
+        Agent._next_id += 1
+        self.id = "agent-%d" % Agent._next_id
     def __str__(self):
         return "Agent from team %i, energy %i" % (self.team,self.energy)
     def attack(self, other, offset = 0, contested = False):

--- a/tests/test_batch_protocol.py
+++ b/tests/test_batch_protocol.py
@@ -1,0 +1,325 @@
+"""Tests for the per-team batch protocol (#23).
+
+The engine groups a tick's per-agent dispatch by team. If a team's mind
+module exposes `act_batch`, all agents on that team are sent in a
+single call per tick; otherwise the engine falls back to the existing
+per-agent path. Pre-planned moves and DQ semantics still apply.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import asyncio
+
+import pytest
+
+import cells
+
+
+def _module(name, mind_cls=None, *, batch=None):
+    """Build a mind module shim. If `batch` is set it'll be exposed as
+    the module's act_batch attribute, triggering the batch path."""
+
+    class M:
+        pass
+
+    m = M()
+    m.AgentMind = mind_cls if mind_cls is not None else _NoopMind
+    m.name = name
+    if batch is not None:
+        m.act_batch = batch
+    return (name, m)
+
+
+class _NoopMind:
+    def __init__(self, cargs):
+        pass
+
+    def act(self, view, msg):
+        return cells.Action(cells.ACT_EAT)
+
+
+def _spawn_extra_agents(game, team, count):
+    """Hand-add `count` agents to `team` at sparse positions. The map must
+    be lockable (post-init) — `add_agent` writes pixels."""
+    positions = [(15, 5 + i * 3) for i in range(count)]
+    game.agent_map.lock()
+    try:
+        for (x, y) in positions:
+            a = cells.Agent(x, y, cells.STARTING_ENERGY, team, game.minds[team], None)
+            game.add_agent(a)
+    finally:
+        game.agent_map.unlock()
+
+
+async def test_batch_called_once_per_team_per_tick():
+    """A team with N agents triggers exactly one act_batch call per tick,
+    receives N entries in the request, and every agent's action lands."""
+    captured = {"calls": 0, "agents_per_call": []}
+
+    async def batch_fn(agents, msg):
+        captured["calls"] += 1
+        captured["agents_per_call"].append(len(agents))
+        return {aid: cells.Action(cells.ACT_LIFT) for (aid, _) in agents}
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+    _spawn_extra_agents(g, 0, 3)  # team 0 now has 4 agents
+
+    await g.tick()
+    assert captured["calls"] == 1
+    assert captured["agents_per_call"] == [4]
+    for a in g.agent_population:
+        if a.team == 0:
+            assert a.last_action.type == cells.ACT_LIFT
+    await g._cancel_all_pending()
+
+
+async def test_batch_request_carries_stable_agent_ids():
+    """Agent.id is stable across ticks for the lifetime of the agent."""
+    seen_ids = []
+
+    async def batch_fn(agents, msg):
+        seen_ids.append([aid for (aid, _) in agents])
+        return {aid: cells.Action(cells.ACT_EAT) for (aid, _) in agents}
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    await g.tick()
+    await g.tick()
+    assert seen_ids[0] == seen_ids[1]  # same agent, same id, two ticks
+    await g._cancel_all_pending()
+
+
+async def test_mixed_teams_batch_and_per_agent():
+    """One team uses act_batch, the other uses per-agent. Both work in the
+    same game on the same tick."""
+    batch_calls = {"n": 0}
+    per_agent_calls = {"n": 0}
+
+    async def batch_fn(agents, msg):
+        batch_calls["n"] += 1
+        return {aid: cells.Action(cells.ACT_LIFT) for (aid, _) in agents}
+
+    class CountingMind:
+        def __init__(self, cargs):
+            pass
+
+        def act(self, view, msg):
+            per_agent_calls["n"] += 1
+            return cells.Action(cells.ACT_DROP)
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("per", CountingMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    await g.tick()
+    assert batch_calls["n"] == 1
+    assert per_agent_calls["n"] == 1  # one agent on team 1
+    team0 = [a for a in g.agent_population if a.team == 0][0]
+    team1 = [a for a in g.agent_population if a.team == 1][0]
+    assert team0.last_action.type == cells.ACT_LIFT
+    assert team1.last_action.type == cells.ACT_DROP
+    await g._cancel_all_pending()
+
+
+async def test_missing_agent_in_batch_response_strikes_and_falls_back():
+    """If the batch response omits an agent, that agent gets a strike and
+    falls back to its last_action."""
+    state = {"missing_id": None}
+
+    async def batch_fn(agents, msg):
+        if state["missing_id"] is None:
+            # Tick 1: seed last_action for everyone, mark the first agent
+            # as the one we'll drop on the next tick.
+            state["missing_id"] = agents[0][0]
+            return {aid: cells.Action(cells.ACT_LIFT) for (aid, _) in agents}
+        return {
+            aid: cells.Action(cells.ACT_DROP)
+            for (aid, _) in agents
+            if aid != state["missing_id"]
+        }
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=10,
+    )
+    _spawn_extra_agents(g, 0, 2)  # team 0 has 3 agents
+
+    await g.tick()
+    strikes_before = g.strikes[0]
+
+    await g.tick()
+    assert g.strikes[0] == strikes_before + 1
+
+    missing = next(a for a in g.agent_population if a.id == state["missing_id"])
+    assert missing.last_action.type == cells.ACT_LIFT
+    others = [
+        a for a in g.agent_population
+        if a.team == 0 and a.id != state["missing_id"]
+    ]
+    for a in others:
+        assert a.last_action.type == cells.ACT_DROP
+    await g._cancel_all_pending()
+
+
+async def test_batch_pre_planned_moves_consumed_from_queue():
+    """A batch entry that's a list of Actions is consumed one-per-tick from
+    the agent's action_queue. Subsequent ticks don't re-call act_batch
+    until the queue drains."""
+    call_count = {"n": 0}
+
+    async def batch_fn(agents, msg):
+        call_count["n"] += 1
+        # Return a 3-action plan for every agent on the first call.
+        return {
+            aid: [
+                cells.Action(cells.ACT_LIFT),
+                cells.Action(cells.ACT_DROP),
+                cells.Action(cells.ACT_EAT),
+            ]
+            for (aid, _) in agents
+        }
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+
+    team0 = [a for a in g.agent_population if a.team == 0][0]
+
+    await g.tick()
+    assert call_count["n"] == 1
+    assert team0.last_action.type == cells.ACT_LIFT
+
+    await g.tick()
+    # Queue still has actions, no new batch call.
+    assert call_count["n"] == 1
+    assert team0.last_action.type == cells.ACT_DROP
+
+    await g.tick()
+    assert call_count["n"] == 1
+    assert team0.last_action.type == cells.ACT_EAT
+
+    # Queue drained -> next tick triggers a new call.
+    await g.tick()
+    assert call_count["n"] == 2
+    await g._cancel_all_pending()
+
+
+async def test_batch_timeout_strikes_every_pending_agent(monkeypatch):
+    """If the batch call exceeds the soft timeout, each pending agent on
+    that team gets a strike and falls back to last_action."""
+    monkeypatch.setattr(cells, "SOFT_TIMEOUT_SECONDS", 0.05)
+
+    async def slow_batch(agents, msg):
+        await asyncio.sleep(2.0)
+        return {aid: cells.Action(cells.ACT_EAT) for (aid, _) in agents}
+
+    g = cells.Game(
+        20,
+        [_module("slow", batch=slow_batch), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=10,
+    )
+    _spawn_extra_agents(g, 0, 2)  # team 0 has 3 agents
+
+    await g.tick()
+    assert g.strikes[0] == 3
+    # All strikes recorded as soft_timeout.
+    soft = [e for e in g.strike_log if e[2] == "soft_timeout"]
+    assert len(soft) == 3
+    await g._cancel_all_pending()
+
+
+async def test_batch_exception_strikes_every_pending_agent():
+    """If act_batch raises, each pending agent gets an 'exception' strike."""
+    async def boom_batch(agents, msg):
+        raise RuntimeError("boom")
+
+    g = cells.Game(
+        20,
+        [_module("boom", batch=boom_batch), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=10,
+    )
+    _spawn_extra_agents(g, 0, 1)  # team 0 has 2 agents
+
+    await g.tick()
+    assert g.strikes[0] == 2
+    reasons = [e[2] for e in g.strike_log]
+    assert reasons.count("exception") == 2
+    await g._cancel_all_pending()
+
+
+async def test_disqualified_team_skips_batch_call():
+    """A DQ'd team's act_batch isn't called — agents NOOP unconditionally."""
+    call_count = {"n": 0}
+
+    async def batch_fn(agents, msg):
+        call_count["n"] += 1
+        return {aid: cells.Action(cells.ACT_LIFT) for (aid, _) in agents}
+
+    g = cells.Game(
+        20,
+        [_module("batch", batch=batch_fn), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+    )
+    g.disqualified.add(0)
+
+    await g.tick()
+    assert call_count["n"] == 0
+    team0 = [a for a in g.agent_population if a.team == 0][0]
+    # DQ path returns ACT_EAT but doesn't update last_action (existing
+    # convention — see _act_for_agent).
+    assert team0.last_action is None
+    await g._cancel_all_pending()
+
+
+async def test_malformed_batch_response_strikes_with_malformed_reason():
+    """A non-dict response strikes every pending agent as 'malformed'."""
+    async def bogus_batch(agents, msg):
+        return "not a dict"
+
+    g = cells.Game(
+        20,
+        [_module("bogus", batch=bogus_batch), _module("noop", _NoopMind)],
+        symmetric=True,
+        max_time=20,
+        headless=True,
+        strike_threshold=10,
+    )
+
+    await g.tick()
+    assert g.strikes[0] == 1
+    assert g.strike_log[0][2] == "malformed"
+    await g._cancel_all_pending()

--- a/tests/test_http_mind.py
+++ b/tests/test_http_mind.py
@@ -133,6 +133,69 @@ async def test_response_missing_type_returns_none():
     await mind.aclose()
 
 
+async def test_act_batch_round_trip():
+    """The batch endpoint serialises the team's agents and parses the
+    keyed response back into per-agent actions."""
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "actions": [
+                    {"id": "agent-0", "action": {"type": cells.ACT_LIFT}},
+                    {"id": "agent-1", "action": {"actions": [{"type": cells.ACT_DROP}, {"type": cells.ACT_EAT}]}},
+                ]
+            },
+        )
+
+    mind = _make_mind(handler)
+    v0 = _make_view()
+    v1 = _make_view()
+    out = await mind.act_batch([("agent-0", v0), ("agent-1", v1)], ["hello"])
+
+    body = captured["body"]
+    assert body["tick"] == 1
+    assert body["messages"] == ["hello"]
+    assert [a["id"] for a in body["agents"]] == ["agent-0", "agent-1"]
+    assert body["agents"][0]["view"]["me"]["pos"] == [5, 5]
+
+    assert isinstance(out["agent-0"], cells.Action)
+    assert out["agent-0"].type == cells.ACT_LIFT
+    assert isinstance(out["agent-1"], list)
+    assert [a.type for a in out["agent-1"]] == [cells.ACT_DROP, cells.ACT_EAT]
+    await mind.aclose()
+
+
+async def test_act_batch_http_error_returns_empty():
+    def handler(request):
+        return httpx.Response(500, text="upstream error")
+
+    mind = _make_mind(handler)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out == {}
+    await mind.aclose()
+
+
+async def test_act_batch_partial_response():
+    """Missing entries in the response dict are simply absent from the
+    result; the engine handles the per-agent fallback."""
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"actions": [{"id": "agent-1", "action": {"type": cells.ACT_LIFT}}]},
+        )
+
+    mind = _make_mind(handler)
+    out = await mind.act_batch(
+        [("agent-0", _make_view()), ("agent-1", _make_view())], []
+    )
+    assert "agent-0" not in out
+    assert out["agent-1"].type == cells.ACT_LIFT
+    await mind.aclose()
+
+
 async def test_http_mind_plays_a_full_game():
     """End-to-end: an HttpMind opponent runs through the engine without
     errors. The remote bot just eats every tick."""

--- a/tests/test_mcp_mind.py
+++ b/tests/test_mcp_mind.py
@@ -119,6 +119,53 @@ async def test_text_content_malformed_returns_none():
     assert result is None
 
 
+async def test_act_batch_round_trip():
+    """McpMind.act_batch calls the `act_batch` tool and parses the
+    structuredContent response into per-agent actions."""
+    session = FakeSession(
+        structured={
+            "actions": [
+                {"id": "agent-0", "action": {"type": cells.ACT_LIFT}},
+                {"id": "agent-1", "action": {"actions": [{"type": cells.ACT_DROP}]}},
+            ]
+        }
+    )
+    mind = McpMind("bot", session=session)
+    out = await mind.act_batch(
+        [("agent-0", _make_view()), ("agent-1", _make_view())], ["hello"]
+    )
+    assert session.calls[0][0] == "act_batch"
+    args = session.calls[0][1]
+    assert args["tick"] == 1
+    assert args["messages"] == ["hello"]
+    assert [a["id"] for a in args["agents"]] == ["agent-0", "agent-1"]
+    assert out["agent-0"].type == cells.ACT_LIFT
+    assert isinstance(out["agent-1"], list)
+    assert out["agent-1"][0].type == cells.ACT_DROP
+
+
+async def test_act_batch_text_content():
+    payload = {"actions": [{"id": "agent-0", "action": {"type": cells.ACT_EAT}}]}
+    session = FakeSession(text=json.dumps(payload))
+    mind = McpMind("bot", session=session)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out["agent-0"].type == cells.ACT_EAT
+
+
+async def test_act_batch_call_raises_returns_empty():
+    session = FakeSession(raises=RuntimeError("boom"))
+    mind = McpMind("bot", session=session)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out == {}
+
+
+async def test_act_batch_is_error_returns_empty():
+    session = FakeSession(structured={"actions": []}, is_error=True)
+    mind = McpMind("bot", session=session)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out == {}
+
+
 async def test_mcp_mind_plays_a_full_game():
     session = FakeSession(structured={"type": cells.ACT_EAT})
     mcp_bot = McpMind("mcp_bot", session=session)

--- a/transports/http_mind.py
+++ b/transports/http_mind.py
@@ -57,6 +57,27 @@ def _parse_action(payload: Any):
     return None
 
 
+def _parse_batch_response(payload: Any) -> dict:
+    """Decode a batch response body into {agent_id: Action | list[Action] | None}.
+
+    Missing or malformed entries are simply omitted; the engine treats
+    absence as a strike + last_action fallback."""
+    if not isinstance(payload, dict):
+        return {}
+    actions = payload.get("actions")
+    if not isinstance(actions, list):
+        return {}
+    out = {}
+    for entry in actions:
+        if not isinstance(entry, dict):
+            continue
+        aid = entry.get("id")
+        if not isinstance(aid, str):
+            continue
+        out[aid] = _parse_action(entry.get("action"))
+    return out
+
+
 class HttpMind:
     """A mind backed by an HTTP endpoint. Acts as a mind module from the
     engine's perspective: exposes `name` and `AgentMind`.
@@ -101,6 +122,23 @@ class HttpMind:
             return _parse_action(r.json())
         except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return None
+
+    async def act_batch(self, agents, msg):
+        """Per-team batch endpoint (#23). `agents` is a list of
+        (agent_id, WorldView). Returns {agent_id: Action | list[Action] | None}."""
+        if not agents:
+            return {}
+        payload = {
+            "tick": int(agents[0][1].tick),
+            "messages": list(msg),
+            "agents": [{"id": aid, "view": v.to_json()} for (aid, v) in agents],
+        }
+        try:
+            r = await self._client.post(self._url, json=payload, headers=self._headers)
+            r.raise_for_status()
+            return _parse_batch_response(r.json())
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+            return {}
 
     async def aclose(self):
         await self._client.aclose()

--- a/transports/mcp_mind.py
+++ b/transports/mcp_mind.py
@@ -25,7 +25,7 @@ import json
 from contextlib import AsyncExitStack
 from typing import Any
 
-from transports.http_mind import _parse_action
+from transports.http_mind import _parse_action, _parse_batch_response
 
 import cells
 
@@ -47,6 +47,25 @@ def _parse_result(result) -> Any:
         except json.JSONDecodeError:
             return None
     return None
+
+
+def _parse_batch_result(result) -> dict:
+    """Parse an MCP CallToolResult into {agent_id: Action | list[Action] | None}."""
+    if getattr(result, "isError", False):
+        return {}
+    structured = getattr(result, "structuredContent", None)
+    if structured:
+        return _parse_batch_response(structured)
+    content = getattr(result, "content", None) or []
+    for item in content:
+        text = getattr(item, "text", None)
+        if text is None:
+            continue
+        try:
+            return _parse_batch_response(json.loads(text))
+        except json.JSONDecodeError:
+            return {}
+    return {}
 
 
 class McpMind:
@@ -120,6 +139,23 @@ class McpMind:
             return _parse_result(result)
         except Exception:
             return None
+
+    async def act_batch(self, agents, msg):
+        """Per-team batch endpoint (#23). Calls the contestant's `act_batch`
+        MCP tool with the team's full agent list."""
+        if not agents:
+            return {}
+        arguments = {
+            "tick": int(agents[0][1].tick),
+            "messages": list(msg),
+            "agents": [{"id": aid, "view": v.to_json()} for (aid, v) in agents],
+        }
+        try:
+            await self._ensure_session()
+            result = await self._session.call_tool("act_batch", arguments=arguments)
+        except Exception:
+            return {}
+        return _parse_batch_result(result)
 
     async def aclose(self):
         if self._stack is not None:


### PR DESCRIPTION
Closes #23.

## Summary

Today the engine calls `act()` once per agent per tick, which means a 50-agent team makes 50 HTTP/MCP requests every tick. This change groups dispatch by team and lets a mind module opt into a batch protocol — one call per team per tick — by exposing `act_batch(agents, msg)` where `agents` is `[(agent_id, WorldView), ...]` and the return is `{agent_id: Action | list[Action] | None}`.

Engine path:
- `Game.run_agents` groups the per-tick `(agent, WorldView)` pairs by team.
- For each team, if the mind module has `act_batch`, dispatch one call; otherwise fall back to the existing per-agent `_act_for_agent` path (preserves the #18 soft/hard timeout model + pending-task carryover for in-process and async-but-non-batch minds).
- Pre-planned moves still apply: a list response goes into the agent's `action_queue` and ticks consume one entry at a time before the next batch call.
- Missing entries in the response strike the team (one per missing agent — matches per-agent semantics) and fall back to `last_action`.
- DQ teams skip the batch call entirely.

Wire format (HTTP request body, MCP `act_batch` tool args):

```json
{
  "tick": 142,
  "messages": ["..."],
  "agents": [
    {"id": "agent-0", "view": { ...WorldView.to_json()... }},
    {"id": "agent-1", "view": { ... }}
  ]
}
```

Wire format (response):

```json
{
  "actions": [
    {"id": "agent-0", "action": {"type": 2}},
    {"id": "agent-1", "action": {"actions": [{"type": 1, "data": [3,4]}]}}
  ]
}
```

`Agent.id` is engine-assigned (`"agent-N"` from a class-level counter) and stable across ticks for the lifetime of the agent.

## Test plan

- [x] `tests/test_batch_protocol.py` — 9 new tests covering: one-call-per-tick, stable IDs across ticks, mixed batch+per-agent teams in the same game, missing-entry strike + fallback, pre-planned-moves carryover from a batch response, soft-timeout per-pending-agent strikes, exception strikes, DQ skip, malformed-response strike.
- [x] `tests/test_http_mind.py` — `act_batch` round-trip, HTTP error → empty dict, partial response handling.
- [x] `tests/test_mcp_mind.py` — `act_batch` over structuredContent, over textContent, raises → empty, isError → empty.
- [x] Full suite: `SDL_VIDEODRIVER=dummy python -m pytest -q` → 77 passed, 1 skipped (cython helper, pre-existing).

## Notes / deferred

- Batch path uses a single `wait_for(SOFT_TIMEOUT_SECONDS)` rather than the soft+hard shielded carryover from #18. A slow batch call can't dribble back across ticks. If we want carryover for batch we can add it as a follow-up.
- The non-batch fallback inside `_dispatch_team` still uses `_act_for_agent`, so async-but-non-batch minds get the existing pending-task behavior unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bD5kSoNozoiB7wMmhS78)_