### PR TITLE
Complete terrain generator test coverage (#6)

### DIFF
--- a/tests/test_terrain_generator.py
+++ b/tests/test_terrain_generator.py
@@ -1,12 +1,27 @@
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import random
+
 import numpy
 import pytest
 
+import cells
 from terrain.generator import terrain_generator
 
 
 @pytest.fixture
 def gen():
     return terrain_generator()
+
+
+def _module(name, mind_cls):
+    class M:
+        pass
+    m = M()
+    m.AgentMind = mind_cls
+    m.name = name
+    return (name, m)
 
 
 def test_create_random_shape_and_range(gen):
@@ -17,24 +32,64 @@ def test_create_random_shape_and_range(gen):
     assert arr.min() >= 0 and arr.max() <= 10
 
 
-def test_create_perlin_shape_and_dtype(gen):
+def test_create_perlin_shape_dtype_and_range(gen):
     numpy.random.seed(0)
     arr = gen.create_perlin((30, 30), 10)
     assert arr.shape == (30, 30)
-    assert arr.dtype == int
+    assert arr.dtype.kind in ("i", "u")
+    assert arr.min() >= 0 and arr.max() <= 10
 
 
-def test_create_streak_runs(gen):
-    arr = gen.create_streak((20, 20), 5)
-    assert numpy.asarray(arr).shape == (20, 20)
+def test_create_streak_shape_dtype_and_range(gen):
+    random.seed(0)
+    arr = numpy.asarray(gen.create_streak((20, 20), 5))
+    assert arr.shape == (20, 20)
+    assert arr.dtype.kind in ("i", "u")
+    assert arr.min() >= 0 and arr.max() <= 5
 
 
-def test_create_simple_runs(gen):
-    arr = gen.create_simple((16, 16), 5)
-    assert numpy.asarray(arr).shape == (16, 16)
+def test_create_simple_shape_dtype_and_range(gen):
+    random.seed(0)
+    arr = numpy.asarray(gen.create_simple((16, 16), 5))
+    assert arr.shape == (16, 16)
+    assert arr.dtype.kind in ("i", "u")
+    assert arr.min() >= 0 and arr.max() <= 5
 
 
-def test_symmetry(gen):
+def test_symmetry_perlin(gen):
     numpy.random.seed(0)
     arr = gen.create_perlin((16, 16), 10, symmetric=True)
     assert numpy.array_equal(arr, arr.T)
+
+
+def test_symmetry_streak(gen):
+    random.seed(0)
+    arr = numpy.asarray(gen.create_streak((16, 16), 5, symmetric=True))
+    assert numpy.array_equal(arr, arr.T)
+
+
+async def test_game_uses_generators_without_raising():
+    random.seed(0)
+    numpy.random.seed(0)
+
+    class EatMind:
+        def __init__(self, cargs):
+            pass
+
+        def act(self, view, msg):
+            return cells.Action(cells.ACT_EAT)
+
+    g = cells.Game(
+        50,
+        [_module("a", EatMind), _module("b", EatMind)],
+        symmetric=True,
+        max_time=5,
+        headless=True,
+    )
+    assert g.terr.values is not None
+    assert g.energy_map.values is not None
+    ticks = 0
+    while g.winner is None and ticks < 10:
+        await g.tick()
+        ticks += 1
+    assert ticks > 0


### PR DESCRIPTION
Closes #6

## Summary

The terrain generator (`terrain/generator.py`) was already ported to Python 3 in prior work. What was missing to close the issue was the test coverage specified in the "Done when" criteria:

- `create_streak` and `create_simple` only had shape assertions — missing dtype and value-range checks
- `create_perlin` was missing a value-range check
- No symmetry test for `create_streak` (only perlin was covered)
- No Game integration test exercising `set_perlin` + `set_streak` end-to-end

## Changes

Single file: `tests/test_terrain_generator.py`

- **Renamed** `test_create_perlin_shape_and_dtype` → `test_create_perlin_shape_dtype_and_range` — adds `arr.max() <= 10` assertion
- **Replaced** `test_create_streak_runs` with `test_create_streak_shape_dtype_and_range` — asserts dtype is integer, values in `[0, 5]`
- **Replaced** `test_create_simple_runs` with `test_create_simple_shape_dtype_and_range` — asserts dtype is integer, values in `[0, 5]`
- **Renamed** `test_symmetry` → `test_symmetry_perlin` (no behaviour change)
- **Added** `test_symmetry_streak` — `create_streak((16,16), 5, symmetric=True)` satisfies `arr == arr.T`
- **Added** `test_game_uses_generators_without_raising` (async) — constructs `Game(bounds=50, symmetric=True)` and ticks it, exercising the `set_perlin` / `set_streak` path through `ScalarMapLayer`

## Test plan

- [ ] `SDL_VIDEODRIVER=dummy python -m pytest tests/test_terrain_generator.py -v` — all 8 tests pass
- [ ] Full suite unaffected: no other test file touches `terrain/generator.py`
- [ ] Value-range bounds hold by construction (streak/simple clamp at each step; perlin output ≤ roughness × 0.875)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3m9naCZdg1igZU2MBxstg)_