### PR TITLE
Bots.toml as the canonical mind config (#24)

### DIFF
--- a/bots.example.toml
+++ b/bots.example.toml
@@ -1,0 +1,45 @@
+# Example bot registration config for cells (#24).
+#
+# Run head-to-head:
+#     python cells.py --bots bots.example.toml alice bob
+#
+# Run round-robin tournament across every bot in this file:
+#     python tournament.py --bots bots.example.toml
+#
+# Run a tournament across a subset:
+#     python tournament.py --bots bots.example.toml alice bob carol
+
+# In-process mind: imported directly into the engine. Lowest latency,
+# no network roundtrip. `module` is a Python import path.
+[bots.alice]
+transport = "in_process"
+module = "minds.mind1"
+
+# HTTP mind: cells POSTs the per-tick world view (or the per-team
+# batch payload, see #23) to `url`. Optional `headers` for auth,
+# optional `timeout` (seconds, default 5.0).
+[bots.bob]
+transport = "http"
+url = "https://bob.example.com/cells/act"
+headers = { Authorization = "Bearer xyz" }
+timeout = 5.0
+
+# MCP mind via stdio: cells spawns the contestant's server as a
+# subprocess and calls the `act` (or `act_batch`) tool over stdio.
+[bots.carol]
+transport = "mcp"
+mode = "stdio"
+command = ["python", "bots/carol_server.py"]
+
+# MCP mind via SSE: cells connects to a hosted MCP endpoint.
+[bots.dave]
+transport = "mcp"
+mode = "sse"
+url = "https://dave.example.com/mcp"
+
+# Tournament-level knobs. All keys optional; defaults shown.
+[tournament]
+bounds = 300
+symmetric = true
+rounds = 4
+max_time = 5000

--- a/cells.py
+++ b/cells.py
@@ -953,7 +953,15 @@ def _parse_cli(argv=None):
     parser.add_argument(
         "minds",
         nargs="*",
-        help="Mind module names from minds/. Need 2+ to override default.cfg.",
+        help=(
+            "With --bots: bot names from bots.toml to play against each other. "
+            "Without --bots: legacy mind module names from minds/ — deprecated."
+        ),
+    )
+    parser.add_argument(
+        "--bots",
+        default=None,
+        help="Path to bots.toml. The canonical source of mind config (#24).",
     )
     parser.add_argument(
         "--headless",
@@ -984,6 +992,20 @@ def main(argv=None):
     if args.seed is not None:
         random.seed(args.seed)
         numpy.random.seed(args.seed)
+
+    if args.bots:
+        from config import load_bots, select_bots
+
+        mind_list, tournament_cfg = load_bots(args.bots)
+        if args.minds:
+            mind_list = select_bots(mind_list, args.minds)
+        bounds = int(tournament_cfg.get("bounds", 300))
+        symmetric = bool(tournament_cfg.get("symmetric", True))
+        return args, bounds, symmetric, mind_list
+
+    from config import warn_legacy_cfg
+
+    warn_legacy_cfg("default.cfg")
 
     try:
         config.read('default.cfg')

--- a/config.py
+++ b/config.py
@@ -1,0 +1,113 @@
+"""Bot registration loader (#24).
+
+Parses a bots.toml describing the contestants in a tournament. Each
+[bots.NAME] section selects a transport (in_process | http | mcp) and
+the parameters needed to construct that mind. The optional [tournament]
+section carries shared knobs (bounds, symmetric, rounds, max_time).
+
+Loaded values are returned in the (name, mind_module) shape that
+cells.Game expects so the engine wiring is unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+
+from transports.http_mind import HttpMind
+from transports.mcp_mind import McpMind
+
+
+def _load_in_process(name, spec):
+    module_path = spec.get("module")
+    if not module_path:
+        raise ValueError("bot %r (in_process) requires 'module'" % name)
+    mind = importlib.import_module(module_path)
+    mind.name = name
+    return mind
+
+
+def _load_http(name, spec):
+    url = spec.get("url")
+    if not url:
+        raise ValueError("bot %r (http) requires 'url'" % name)
+    return HttpMind(
+        name,
+        url,
+        headers=spec.get("headers"),
+        timeout=spec.get("timeout", 5.0),
+    )
+
+
+def _load_mcp(name, spec):
+    mode = spec.get("mode")
+    if mode == "stdio":
+        command = spec.get("command")
+        if not command:
+            raise ValueError("bot %r (mcp/stdio) requires 'command'" % name)
+        return McpMind(name, server_command=list(command))
+    if mode == "sse":
+        url = spec.get("url")
+        if not url:
+            raise ValueError("bot %r (mcp/sse) requires 'url'" % name)
+        return McpMind(name, server_url=url)
+    raise ValueError(
+        "bot %r has unknown mcp mode %r; use 'stdio' or 'sse'" % (name, mode)
+    )
+
+
+_LOADERS = {
+    "in_process": _load_in_process,
+    "http": _load_http,
+    "mcp": _load_mcp,
+}
+
+
+def load_bots(path):
+    """Read `path` and return (mind_list, tournament_cfg).
+
+    `mind_list` is `[(name, mind_module), ...]` in the order the [bots.*]
+    sections appear, so it can be handed straight to `cells.Game`.
+    `tournament_cfg` is the raw [tournament] dict, possibly empty.
+    """
+    cfg = tomllib.loads(Path(path).read_text())
+    bots_section = cfg.get("bots") or {}
+    if not bots_section:
+        raise ValueError("%s has no [bots.<name>] sections" % path)
+
+    mind_list = []
+    for name, spec in bots_section.items():
+        transport = spec.get("transport")
+        if transport is None:
+            raise ValueError("bot %r is missing required 'transport' field" % name)
+        loader = _LOADERS.get(transport)
+        if loader is None:
+            raise ValueError(
+                "bot %r has unknown transport %r; use one of %s"
+                % (name, transport, sorted(_LOADERS))
+            )
+        mind_list.append((name, loader(name, spec)))
+
+    return mind_list, cfg.get("tournament") or {}
+
+
+def select_bots(mind_list, names):
+    """Filter `mind_list` to the subset `names`, preserving the requested
+    order. Raises if any name isn't registered."""
+    by_name = dict(mind_list)
+    missing = [n for n in names if n not in by_name]
+    if missing:
+        raise ValueError("unknown bots in --bots config: %s" % missing)
+    return [(n, by_name[n]) for n in names]
+
+
+def warn_legacy_cfg(path):
+    """Emit a stderr deprecation notice when a legacy configparser cfg
+    drives mind selection. Done as a print rather than warnings.warn so
+    end users running the CLI actually see it without setting filters."""
+    sys.stderr.write(
+        "DeprecationWarning: %s-based mind config is deprecated; "
+        "use --bots bots.toml instead. See bots.example.toml.\n" % path
+    )

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -1,0 +1,376 @@
+"""Tests for the bots.toml loader (#24).
+
+Covers parsing all four transport types with mocked HTTP / MCP
+clients, error reporting on missing or unknown fields, subset
+selection, [tournament] propagation, and end-to-end coverage of
+the legacy deprecation path through the cells / tournament CLIs.
+"""
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from config import load_bots, select_bots
+from transports.http_mind import HttpMind
+from transports.mcp_mind import McpMind
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _write(tmp_path, body):
+    path = tmp_path / "bots.toml"
+    path.write_text(textwrap.dedent(body))
+    return str(path)
+
+
+def test_in_process_transport(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+    """)
+    mind_list, t = load_bots(path)
+    assert len(mind_list) == 1
+    name, mind = mind_list[0]
+    assert name == "alice"
+    assert hasattr(mind, "AgentMind")
+    assert mind.name == "alice"
+    assert t == {}
+
+
+def test_http_transport_constructs_httpmind(tmp_path):
+    path = _write(tmp_path, """
+        [bots.bob]
+        transport = "http"
+        url = "https://bob.example.com/act"
+        timeout = 7.5
+        headers = { Authorization = "Bearer xyz" }
+    """)
+    mind_list, _ = load_bots(path)
+    name, mind = mind_list[0]
+    assert name == "bob"
+    assert isinstance(mind, HttpMind)
+    assert mind._url == "https://bob.example.com/act"
+    assert mind._timeout == 7.5
+    assert mind._headers == {"Authorization": "Bearer xyz"}
+
+
+def test_mcp_stdio_transport(tmp_path):
+    path = _write(tmp_path, """
+        [bots.carol]
+        transport = "mcp"
+        mode = "stdio"
+        command = ["python", "bots/carol_server.py"]
+    """)
+    mind_list, _ = load_bots(path)
+    name, mind = mind_list[0]
+    assert name == "carol"
+    assert isinstance(mind, McpMind)
+    assert mind._server_command == ["python", "bots/carol_server.py"]
+    assert mind._server_url is None
+
+
+def test_mcp_sse_transport(tmp_path):
+    path = _write(tmp_path, """
+        [bots.dave]
+        transport = "mcp"
+        mode = "sse"
+        url = "https://dave.example.com/mcp"
+    """)
+    mind_list, _ = load_bots(path)
+    name, mind = mind_list[0]
+    assert isinstance(mind, McpMind)
+    assert mind._server_url == "https://dave.example.com/mcp"
+    assert mind._server_command is None
+
+
+def test_all_four_transports_in_one_file(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+
+        [bots.bob]
+        transport = "http"
+        url = "https://bob.example.com/act"
+
+        [bots.carol]
+        transport = "mcp"
+        mode = "stdio"
+        command = ["python", "x.py"]
+
+        [bots.dave]
+        transport = "mcp"
+        mode = "sse"
+        url = "https://dave.example.com/mcp"
+    """)
+    mind_list, _ = load_bots(path)
+    assert [n for (n, _) in mind_list] == ["alice", "bob", "carol", "dave"]
+    assert isinstance(mind_list[1][1], HttpMind)
+    assert isinstance(mind_list[2][1], McpMind)
+    assert isinstance(mind_list[3][1], McpMind)
+
+
+def test_tournament_section_propagates(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+
+        [tournament]
+        bounds = 50
+        symmetric = false
+        rounds = 7
+        max_time = 1234
+    """)
+    _, t = load_bots(path)
+    assert t == {"bounds": 50, "symmetric": False, "rounds": 7, "max_time": 1234}
+
+
+def test_missing_transport_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        module = "minds.mind1"
+    """)
+    with pytest.raises(ValueError, match="missing required 'transport'"):
+        load_bots(path)
+
+
+def test_unknown_transport_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "ftp"
+    """)
+    with pytest.raises(ValueError, match="unknown transport"):
+        load_bots(path)
+
+
+def test_unknown_mcp_mode_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "mcp"
+        mode = "websocket"
+    """)
+    with pytest.raises(ValueError, match="unknown mcp mode"):
+        load_bots(path)
+
+
+def test_in_process_missing_module_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+    """)
+    with pytest.raises(ValueError, match="requires 'module'"):
+        load_bots(path)
+
+
+def test_http_missing_url_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "http"
+    """)
+    with pytest.raises(ValueError, match="requires 'url'"):
+        load_bots(path)
+
+
+def test_mcp_stdio_missing_command_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "mcp"
+        mode = "stdio"
+    """)
+    with pytest.raises(ValueError, match="requires 'command'"):
+        load_bots(path)
+
+
+def test_mcp_sse_missing_url_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "mcp"
+        mode = "sse"
+    """)
+    with pytest.raises(ValueError, match="requires 'url'"):
+        load_bots(path)
+
+
+def test_no_bots_section_raises(tmp_path):
+    path = _write(tmp_path, """
+        [tournament]
+        bounds = 50
+    """)
+    with pytest.raises(ValueError, match="no \\[bots"):
+        load_bots(path)
+
+
+def test_select_bots_subset_preserves_order(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+
+        [bots.bob]
+        transport = "in_process"
+        module = "minds.mind2"
+
+        [bots.carol]
+        transport = "in_process"
+        module = "minds.mind3"
+    """)
+    mind_list, _ = load_bots(path)
+    sub = select_bots(mind_list, ["carol", "alice"])
+    assert [n for (n, _) in sub] == ["carol", "alice"]
+
+
+def test_select_bots_unknown_name_raises(tmp_path):
+    path = _write(tmp_path, """
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+    """)
+    mind_list, _ = load_bots(path)
+    with pytest.raises(ValueError, match="unknown bots"):
+        select_bots(mind_list, ["alice", "ghost"])
+
+
+# ---------------------------------------------------------------------------
+# CLI integration via subprocess.
+
+def _cells(args, cwd, timeout=30):
+    return subprocess.run(
+        [sys.executable, str(REPO / "cells.py"), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "SDL_VIDEODRIVER": "dummy"},
+    )
+
+
+def _tournament(args, cwd, timeout=120):
+    return subprocess.run(
+        [sys.executable, str(REPO / "tournament.py"), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "SDL_VIDEODRIVER": "dummy"},
+    )
+
+
+def _write_in_process_toml(tmp_path, bounds=30):
+    body = textwrap.dedent("""
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+
+        [bots.bob]
+        transport = "in_process"
+        module = "minds.mind2"
+
+        [bots.carol]
+        transport = "in_process"
+        module = "minds.mind3"
+
+        [tournament]
+        bounds = %d
+        symmetric = true
+    """ % bounds)
+    path = tmp_path / "bots.toml"
+    path.write_text(body)
+    return str(path)
+
+
+def test_cells_runs_with_bots_flag(tmp_path):
+    bots = _write_in_process_toml(tmp_path)
+    result = _cells(
+        ["--headless", "--max-time", "30", "--seed", "1", "--bots", bots, "alice", "bob"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "It's a draw!" in result.stdout or "Winner is" in result.stdout
+    # No deprecation warning when --bots is used.
+    assert "DeprecationWarning" not in result.stderr
+
+
+def test_cells_legacy_emits_deprecation_warning(tmp_path):
+    result = _cells(
+        ["--headless", "--max-time", "20", "--seed", "2", "mind1", "mind2"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DeprecationWarning" in result.stderr
+    assert "default.cfg" in result.stderr
+
+
+def test_cells_unknown_bot_name_in_subset_fails(tmp_path):
+    bots = _write_in_process_toml(tmp_path)
+    result = _cells(
+        ["--headless", "--max-time", "10", "--bots", bots, "alice", "ghost"],
+        cwd=tmp_path,
+    )
+    assert result.returncode != 0
+    assert "unknown bots" in (result.stderr + result.stdout)
+
+
+def test_tournament_runs_with_bots_flag(tmp_path):
+    bots = _write_in_process_toml(tmp_path)
+    result = _tournament(
+        ["--bots", bots, "--seed", "1", "--rounds", "1", "--max-time", "30"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    csv = tmp_path / "scores.csv"
+    assert csv.exists()
+    rows = [r for r in csv.read_text().splitlines() if r.strip()]
+    names = sorted(r.split(";")[0] for r in rows)
+    assert names == ["alice", "bob", "carol"]
+    assert "DeprecationWarning" not in result.stderr
+
+
+def test_tournament_legacy_emits_deprecation_warning(tmp_path):
+    (tmp_path / "tournament.cfg").write_text(
+        "[minds]\nminds = mind1,mind2\n[terrain]\nbounds = 30\nsymmetric = true\n"
+    )
+    result = _tournament(
+        ["--seed", "2", "--rounds", "1", "--max-time", "20"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DeprecationWarning" in result.stderr
+    assert "tournament.cfg" in result.stderr
+
+
+def test_tournament_section_drives_rounds_and_max_time(tmp_path):
+    body = textwrap.dedent("""
+        [bots.alice]
+        transport = "in_process"
+        module = "minds.mind1"
+
+        [bots.bob]
+        transport = "in_process"
+        module = "minds.mind2"
+
+        [tournament]
+        bounds = 30
+        symmetric = true
+        rounds = 1
+        max_time = 25
+    """)
+    path = tmp_path / "bots.toml"
+    path.write_text(body)
+    result = _tournament(
+        ["--bots", str(path), "--seed", "3"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    csv = tmp_path / "scores.csv"
+    rows = [r for r in csv.read_text().splitlines() if r.strip()]
+    assert len(rows) == 2

--- a/tournament.py
+++ b/tournament.py
@@ -31,7 +31,15 @@ def _parse_cli(argv=None):
     parser.add_argument(
         "minds",
         nargs="*",
-        help="Mind module names from minds/. Need 2+ to override tournament.cfg.",
+        help=(
+            "With --bots: subset of bot names from bots.toml to include. "
+            "Without --bots: legacy mind module names from minds/ — deprecated."
+        ),
+    )
+    parser.add_argument(
+        "--bots",
+        default=None,
+        help="Path to bots.toml. The canonical source of mind config (#24).",
     )
     parser.add_argument(
         "--seed",
@@ -42,14 +50,14 @@ def _parse_cli(argv=None):
     parser.add_argument(
         "--rounds",
         type=int,
-        default=4,
-        help="Number of round-robin rounds. Default: 4.",
+        default=None,
+        help="Number of round-robin rounds. Default: 4 (or [tournament].rounds).",
     )
     parser.add_argument(
         "--max-time",
         type=int,
-        default=5000,
-        help="Tick limit per game. Default: 5000.",
+        default=None,
+        help="Tick limit per game. Default: 5000 (or [tournament].max_time).",
     )
     parser.add_argument(
         "--output",
@@ -89,14 +97,25 @@ async def main_async(argv=None):
         random.seed(args.seed)
         numpy.random.seed(args.seed)
 
-    bounds, symmetric, cfg_minds = _load_config()
+    if args.bots:
+        from config import load_bots, select_bots
 
-    if len(args.minds) >= 2:
-        names = args.minds
+        mind_list, tournament_cfg = load_bots(args.bots)
+        if args.minds:
+            mind_list = select_bots(mind_list, args.minds)
+        bounds = int(tournament_cfg.get("bounds", 300))
+        symmetric = bool(tournament_cfg.get("symmetric", True))
+        rounds = args.rounds if args.rounds is not None else int(tournament_cfg.get("rounds", 4))
+        max_time = args.max_time if args.max_time is not None else int(tournament_cfg.get("max_time", 5000))
     else:
-        names = cfg_minds
+        from config import warn_legacy_cfg
 
-    mind_list = [(n, get_mind(n)) for n in names]
+        warn_legacy_cfg("tournament.cfg")
+        bounds, symmetric, cfg_minds = _load_config()
+        names = args.minds if len(args.minds) >= 2 else cfg_minds
+        mind_list = [(n, get_mind(n)) for n in names]
+        rounds = args.rounds if args.rounds is not None else 4
+        max_time = args.max_time if args.max_time is not None else 5000
 
     scores = [0 for _ in mind_list]
     pairings = [
@@ -105,13 +124,13 @@ async def main_async(argv=None):
         for b in range(a)
     ]
 
-    for round_idx in range(args.rounds):
+    for round_idx in range(rounds):
         # Round-robin games within a round are independent — run them
         # concurrently so a slow async mind in one pair doesn't stall
         # the others. With sync minds this is effectively sequential.
         winners = await asyncio.gather(
             *[
-                _play_game(bounds, pair, symmetric, args.max_time)
+                _play_game(bounds, pair, symmetric, max_time)
                 for pair in pairings
             ]
         )


### PR DESCRIPTION
Closes #24. Closes epic #19.

## Summary

Replaces the legacy `default.cfg` `[minds]` list with a structured TOML schema mapping each bot name to a transport (`in_process` / `http` / `mcp`) and its parameters. Wires `--bots bots.toml` into both `cells.py` and `tournament.py` as the canonical config source.

Per the standup decisions:

1. **`bots.toml`-only canonical path.** With `--bots`, positional arguments are bot names (subset selection from the toml). Without `--bots`, the legacy mind-module-name path still works.
2. **Deprecation warning** on the legacy `default.cfg` / `tournament.cfg` flow — printed to stderr so it's visible to CLI users without warning-filter setup.
3. **Per-game strike threshold only** — no per-bot override in the schema. `bots.toml` carries `[bots.NAME]` sections plus an optional `[tournament]` section for shared knobs (bounds, symmetric, rounds, max_time).

## What changed

- `config.py` *(new)* — `load_bots(path) -> (mind_list, tournament_cfg)` and `select_bots(mind_list, names)` for subset selection. Per-transport loaders (`_load_in_process`, `_load_http`, `_load_mcp`) raise clear `ValueError`s on missing/unknown fields. `warn_legacy_cfg` prints the deprecation notice.
- `cells.py` — adds `--bots PATH` to `_parse_cli`. `main()` reads from `bots.toml` when present, otherwise emits the deprecation warning and falls through to the existing configparser flow.
- `tournament.py` — same `--bots` wiring; `[tournament]` section drives `bounds`, `symmetric`, `rounds`, `max_time` with CLI flags overriding.
- `bots.example.toml` *(new)* — documented sample showing all four transport types.
- `tests/test_bot_config.py` *(new)* — 22 tests.

## Test plan

- [x] **Loader unit tests** (15): per-transport construction (in_process / http / http with headers+timeout / mcp stdio / mcp sse), all-four-in-one-file, `[tournament]` propagation, missing-transport / unknown-transport / unknown-mcp-mode / missing-required-field for each transport, no-bots-section, subset selection preserves order, unknown bot name in subset.
- [x] **CLI integration via subprocess** (7): `cells.py --bots` head-to-head, legacy `cells.py mind1 mind2` still works and emits deprecation warning, unknown bot in subset fails, `tournament.py --bots` writes scores.csv with toml-derived names, legacy `tournament.py` emits deprecation warning, `[tournament].rounds` / `max_time` drive the run when CLI flags are absent.
- [x] Full suite: `SDL_VIDEODRIVER=dummy python -m pytest -q` → 101 passed, 1 skipped (cython helper, pre-existing).

## Notes / deferred

- Legacy `default.cfg` / `tournament.cfg` still auto-create when missing — kept intact so existing user workflows aren't broken. The deprecation message points users at `--bots`. Removing the legacy path is a follow-up.
- HTTP transport doesn't validate `headers` / `timeout` types beyond what `httpx` will surface. TOML's typing is reasonably tight already.
- `select_bots` raises a `ValueError` that propagates as a non-zero exit. Pretty-printing CLI errors is out of scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bD5kSoNozoiB7wMmhS78)_