### PR TITLE
HTTP transport: max response size cap (#43)

### DIFF
--- a/bots.example.toml
+++ b/bots.example.toml
@@ -19,12 +19,15 @@ module = "minds.mind1"
 # batch payload, see #23) to `url`. Optional `headers` for auth,
 # optional `timeout` (seconds, default 5.0). Optional `verify`
 # (default true) — set false only for self-signed test servers.
+# Optional `max_response_bytes` (default 1048576 = 1 MB) caps the
+# response size; oversized payloads are dropped + struck via #25.
 [bots.bob]
 transport = "http"
 url = "https://bob.example.com/cells/act"
 headers = { Authorization = "Bearer xyz" }
 timeout = 5.0
 verify = true
+max_response_bytes = 1048576
 
 # MCP mind via stdio: cells spawns the contestant's server as a
 # subprocess and calls the `act` (or `act_batch`) tool over stdio.

--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ def _load_http(name, spec):
         headers=spec.get("headers"),
         timeout=spec.get("timeout", 5.0),
         verify=spec.get("verify", True),
+        max_response_bytes=spec.get("max_response_bytes", 1_048_576),
     )
 
 

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -90,6 +90,29 @@ def test_http_verify_true_explicit(tmp_path):
     assert mind._verify is True
 
 
+def test_http_max_response_bytes_propagates(tmp_path):
+    path = _write(tmp_path, """
+        [bots.bob]
+        transport = "http"
+        url = "https://bob.example.com/act"
+        max_response_bytes = 4096
+    """)
+    mind_list, _ = load_bots(path)
+    _, mind = mind_list[0]
+    assert mind._max_response_bytes == 4096
+
+
+def test_http_max_response_bytes_default(tmp_path):
+    path = _write(tmp_path, """
+        [bots.bob]
+        transport = "http"
+        url = "https://bob.example.com/act"
+    """)
+    mind_list, _ = load_bots(path)
+    _, mind = mind_list[0]
+    assert mind._max_response_bytes == 1_048_576
+
+
 def test_mcp_stdio_transport(tmp_path):
     path = _write(tmp_path, """
         [bots.carol]

--- a/tests/test_http_mind.py
+++ b/tests/test_http_mind.py
@@ -196,6 +196,80 @@ async def test_act_batch_partial_response():
     await mind.aclose()
 
 
+def test_max_response_bytes_defaults_to_1mb():
+    mind = HttpMind("bot", "https://test.invalid/act")
+    assert mind._max_response_bytes == 1_048_576
+
+
+async def test_oversized_response_returns_none():
+    """A response body exceeding `max_response_bytes` is dropped, mirroring
+    a malformed response — engine falls back to last_action."""
+    huge = {"type": cells.ACT_EAT, "padding": "x" * 200_000}
+
+    def handler(request):
+        return httpx.Response(200, json=huge)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_response_just_under_cap_decoded_normally():
+    """A response within the cap parses normally."""
+    payload = {"type": cells.ACT_EAT}
+
+    def handler(request):
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000_000)
+    agent = mind.AgentMind(None)
+    result = await agent.act(_make_view(), [])
+    assert isinstance(result, cells.Action)
+    assert result.type == cells.ACT_EAT
+    await mind.aclose()
+
+
+async def test_oversized_batch_response_returns_empty_dict():
+    """For act_batch, an oversized response yields {} so the engine strikes
+    every pending agent (per the existing #25 path)."""
+    huge = {
+        "actions": [{"id": "agent-0", "action": {"type": cells.ACT_EAT}}],
+        "padding": "x" * 200_000,
+    }
+
+    def handler(request):
+        return httpx.Response(200, json=huge)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out == {}
+    await mind.aclose()
+
+
+async def test_default_cap_handles_realistic_batch_response():
+    """Default 1 MB cap is generous enough for a 50-agent batch response."""
+    actions = [
+        {"id": f"agent-{i}", "action": {"type": cells.ACT_EAT}} for i in range(50)
+    ]
+
+    def handler(request):
+        return httpx.Response(200, json={"actions": actions})
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport)
+    out = await mind.act_batch(
+        [(f"agent-{i}", _make_view()) for i in range(50)], []
+    )
+    assert len(out) == 50
+    assert all(a.type == cells.ACT_EAT for a in out.values())
+    await mind.aclose()
+
+
 def test_verify_defaults_to_true():
     mind = HttpMind("bot", "https://test.invalid/act")
     assert mind._verify is True

--- a/transports/http_mind.py
+++ b/transports/http_mind.py
@@ -94,12 +94,14 @@ class HttpMind:
         timeout: float = 5.0,
         transport: httpx.AsyncBaseTransport | None = None,
         verify: bool = True,
+        max_response_bytes: int = 1_048_576,
     ):
         self.name = name
         self._url = url
         self._headers = headers or {}
         self._timeout = timeout
         self._verify = verify
+        self._max_response_bytes = max_response_bytes
         client_kwargs = {"timeout": timeout}
         if transport is not None:
             client_kwargs["transport"] = transport
@@ -124,17 +126,33 @@ class HttpMind:
 
         self.AgentMind = _AgentMind
 
+    async def _post_capped(self, payload):
+        """POST `payload` to the bot's URL, return the parsed JSON, or None
+        on error or if the response exceeds `max_response_bytes` (#43).
+
+        The body is streamed and the cap is checked after every chunk so a
+        gigabyte response can't OOM the engine before the JSON decoder
+        notices."""
+        try:
+            async with self._client.stream(
+                "POST", self._url, json=payload, headers=self._headers
+            ) as r:
+                r.raise_for_status()
+                body = bytearray()
+                async for chunk in r.aiter_bytes():
+                    body.extend(chunk)
+                    if len(body) > self._max_response_bytes:
+                        return None
+                return json.loads(bytes(body))
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+            return None
+
     async def _call(self, view, msg):
         payload = {
             "view": view.to_json(),
             "messages": list(msg),
         }
-        try:
-            r = await self._client.post(self._url, json=payload, headers=self._headers)
-            r.raise_for_status()
-            return _parse_action(r.json())
-        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
-            return None
+        return _parse_action(await self._post_capped(payload))
 
     async def act_batch(self, agents, msg):
         """Per-team batch endpoint (#23). `agents` is a list of
@@ -146,12 +164,10 @@ class HttpMind:
             "messages": list(msg),
             "agents": [{"id": aid, "view": v.to_json()} for (aid, v) in agents],
         }
-        try:
-            r = await self._client.post(self._url, json=payload, headers=self._headers)
-            r.raise_for_status()
-            return _parse_batch_response(r.json())
-        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+        raw = await self._post_capped(payload)
+        if raw is None:
             return {}
+        return _parse_batch_response(raw)
 
     async def aclose(self):
         await self._client.aclose()


### PR DESCRIPTION
Closes #43. Second sub-issue of the hardening epic #41.

## Summary

Caps the size of any HTTP response body the engine is willing to read from a bot. A response exceeding `max_response_bytes` (default `1_048_576` = 1 MB) is dropped — `_call` returns `None`, `act_batch` returns `{}`. Both are the same shapes the existing transport returns on parse error, so the engine's #25 strike layer treats it as a malformed response automatically.

```toml
[bots.bob]
transport = "http"
url = "https://bob.example.com/cells/act"
max_response_bytes = 1048576   # default 1 MB; oversized responses are dropped + struck via #25
```

## What changed

- `transports/http_mind.py`:
  - `HttpMind.__init__` accepts `max_response_bytes: int = 1_048_576`, stores `_max_response_bytes`.
  - New `_post_capped(payload)` helper that uses `httpx.AsyncClient.stream(...)` and `aiter_bytes()` to read the response one chunk at a time, aborting the moment cumulative bytes exceed the cap. Returns `None` on cap-hit, HTTP error, or JSON parse error.
  - `_call` and `act_batch` both delegate to `_post_capped`. `_call` wraps with `_parse_action` (already handles `None`); `act_batch` returns `{}` on `None`.
- `config.py` — `_load_http` reads `spec.get("max_response_bytes", 1_048_576)` and passes through.
- `bots.example.toml` — documents the field.

## Test plan

- [x] `tests/test_http_mind.py` — 4 new tests:
  - default cap is 1 MB
  - oversized single response → `None`
  - response just under cap parses normally
  - oversized batch response → `{}` (engine strikes via #25)
  - default 1 MB handles a realistic 50-agent batch response without false positives
- [x] `tests/test_bot_config.py` — 2 new tests: explicit `max_response_bytes` from TOML propagates; absent field defaults to 1 MB.
- [x] Full suite on 3.11 and 3.12: **113 passed, 1 skipped** (was 106 → +7).

## Notes

- Cap is checked after every chunk (not just by `Content-Length`) so chunked-transfer responses without a length header are also bounded.
- The cap protects the engine; bots can still return very large valid responses if they raise the cap on their bot config — the default just means an unconfigured bot can't OOM us by accident.
- Pre-existing transport behavior (HTTP errors, parse errors) is unchanged — they still flow through the same `except (httpx.HTTPError, json.JSONDecodeError, ValueError)` branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bD5kSoNozoiB7wMmhS78)_