### PR TITLE
HTTP transport: bearer-token auth + payload signature (#44)

### DIFF
--- a/bots.example.toml
+++ b/bots.example.toml
@@ -21,10 +21,29 @@ module = "minds.mind1"
 # (default true) — set false only for self-signed test servers.
 # Optional `max_response_bytes` (default 1048576 = 1 MB) caps the
 # response size; oversized payloads are dropped + struck via #25.
+#
+# HMAC mutual auth (#44): set `hmac_secret` to a shared secret (e.g. a
+# base64-encoded 32-byte random value). The engine adds
+# X-Cells-Timestamp and X-Cells-Signature headers to every request and
+# verifies that the bot's response carries matching headers. Requests
+# from the bot side can verify the engine's signature the same way:
+#
+#   import hashlib, hmac, time
+#   def verify(secret, ts, body_bytes, sig):
+#       msg = ts.encode() + b"." + body_bytes
+#       expected = hmac.new(secret.encode(), msg, hashlib.sha256).hexdigest()
+#       return hmac.compare_digest(expected, sig)
+#
+#   def sign(secret, body_bytes):
+#       ts = str(int(time.time()))
+#       sig = hmac.new(secret.encode(), ts.encode() + b"." + body_bytes, hashlib.sha256).hexdigest()
+#       return ts, sig
 [bots.bob]
 transport = "http"
 url = "https://bob.example.com/cells/act"
-headers = { Authorization = "Bearer xyz" }
+hmac_secret = "REPLACE_WITH_32B_BASE64"   # shared secret with the bot operator
+hmac_algorithm = "sha256"                  # default
+hmac_skew_seconds = 30                     # reject responses older than this
 timeout = 5.0
 verify = true
 max_response_bytes = 1048576

--- a/config.py
+++ b/config.py
@@ -40,6 +40,9 @@ def _load_http(name, spec):
         timeout=spec.get("timeout", 5.0),
         verify=spec.get("verify", True),
         max_response_bytes=spec.get("max_response_bytes", 1_048_576),
+        hmac_secret=spec.get("hmac_secret"),
+        hmac_algorithm=spec.get("hmac_algorithm", "sha256"),
+        hmac_skew_seconds=spec.get("hmac_skew_seconds", 30),
     )
 
 

--- a/tests/test_http_mind.py
+++ b/tests/test_http_mind.py
@@ -13,13 +13,35 @@ import os
 
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
+import hashlib
+import hmac as _hmac
 import json
+import time
 
 import httpx
 import pytest
 
 import cells
 from transports.http_mind import HttpMind
+
+
+def _hmac_sign(secret: str, ts: str, body_bytes: bytes) -> str:
+    msg = ts.encode() + b"." + body_bytes
+    return _hmac.new(secret.encode(), msg, hashlib.sha256).hexdigest()
+
+
+def _signed_response(secret: str, body_bytes: bytes, skew: int = 0) -> httpx.Response:
+    ts = str(int(time.time()) + skew)
+    sig = _hmac_sign(secret, ts, body_bytes)
+    return httpx.Response(
+        200,
+        content=body_bytes,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cells-Timestamp": ts,
+            "X-Cells-Signature": sig,
+        },
+    )
 
 
 def _make_mind(handler, name="bot"):
@@ -320,3 +342,117 @@ async def test_http_mind_plays_a_full_game():
         await g.tick()
     assert g.winner is not None
     await http_bot.aclose()
+
+
+# ---------------------------------------------------------------------------
+# HMAC mutual-auth tests (#44)
+# ---------------------------------------------------------------------------
+
+def test_hmac_no_secret_warns(capsys):
+    HttpMind("bot", "https://test.invalid/act")
+    captured = capsys.readouterr()
+    assert "hmac_secret" in captured.err
+    assert "unsigned" in captured.err
+
+
+def test_hmac_with_secret_no_unsigned_warn(capsys):
+    HttpMind("bot", "https://test.invalid/act", hmac_secret="s3cr3t")
+    captured = capsys.readouterr()
+    assert "unsigned" not in captured.err
+
+
+async def test_hmac_signed_response_accepted():
+    """Engine signs outbound request; bot signs response with same key → action decoded."""
+    SECRET = "shared-secret"
+    resp_body = json.dumps({"type": cells.ACT_EAT}).encode()
+    req_captured = {}
+
+    def handler(request):
+        req_captured["ts"] = request.headers.get("X-Cells-Timestamp")
+        req_captured["sig"] = request.headers.get("X-Cells-Signature")
+        # Verify the engine's request signature.
+        expected = _hmac_sign(SECRET, req_captured["ts"], request.content)
+        assert _hmac.compare_digest(expected, req_captured["sig"])
+        return _signed_response(SECRET, resp_body)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret=SECRET)
+    action = await mind.AgentMind(None).act(_make_view(), [])
+    assert isinstance(action, cells.Action)
+    assert action.type == cells.ACT_EAT
+    assert req_captured["ts"] is not None
+    assert req_captured["sig"] is not None
+    await mind.aclose()
+
+
+async def test_hmac_mismatched_response_secret_returns_none():
+    """Bot signs response with wrong key — engine rejects, returns None → strike."""
+    resp_body = json.dumps({"type": cells.ACT_EAT}).encode()
+
+    def handler(request):
+        return _signed_response("wrong-secret", resp_body)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="correct-secret")
+    result = await mind.AgentMind(None).act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_hmac_stale_response_timestamp_returns_none():
+    """Response timestamp older than skew window — engine rejects."""
+    resp_body = json.dumps({"type": cells.ACT_EAT}).encode()
+
+    def handler(request):
+        return _signed_response("s3cr3t", resp_body, skew=-60)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="s3cr3t")
+    result = await mind.AgentMind(None).act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_hmac_missing_response_headers_returns_none():
+    """Bot returns no signature headers — engine rejects."""
+    def handler(request):
+        return httpx.Response(200, json={"type": cells.ACT_EAT})
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="s3cr3t")
+    result = await mind.AgentMind(None).act(_make_view(), [])
+    assert result is None
+    await mind.aclose()
+
+
+async def test_hmac_batch_signed_round_trip():
+    """act_batch signs the batch request; bot signs response — result decoded."""
+    SECRET = "batch-secret"
+    resp_body = json.dumps(
+        {"actions": [{"id": "agent-0", "action": {"type": cells.ACT_EAT}}]}
+    ).encode()
+
+    def handler(request):
+        return _signed_response(SECRET, resp_body)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret=SECRET)
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out["agent-0"].type == cells.ACT_EAT
+    await mind.aclose()
+
+
+async def test_hmac_batch_bad_response_signature_returns_empty():
+    """act_batch with mismatched response signature → {} → engine strikes all agents."""
+    resp_body = json.dumps(
+        {"actions": [{"id": "agent-0", "action": {"type": cells.ACT_EAT}}]}
+    ).encode()
+
+    def handler(request):
+        return _signed_response("wrong-secret", resp_body)
+
+    transport = httpx.MockTransport(handler)
+    mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="correct-secret")
+    out = await mind.act_batch([("agent-0", _make_view())], [])
+    assert out == {}
+    await mind.aclose()

--- a/transports/http_mind.py
+++ b/transports/http_mind.py
@@ -7,6 +7,8 @@ URL and parses the action(s) from the response.
 
 Wire format (request):
     POST <url>
+    X-Cells-Timestamp: <unix_seconds>
+    X-Cells-Signature: HMAC(secret, "<ts>.<body_bytes>")  # when hmac_secret set
     {
       "view": <WorldView.to_json() output>,
       "messages": ["string", ...]
@@ -18,6 +20,10 @@ Wire format (response — single action):
 Wire format (response — pre-planned moves):
     {"actions": [{"type": <int>, "data": [...]}, ...]}
 
+When hmac_secret is configured both sides sign their payloads; the engine
+rejects responses with a missing, stale, or wrong signature (treated as
+malformed — engine falls back to last_action and the DQ layer strikes).
+
 A bot that times out, returns malformed JSON, or returns 5xx is treated
 the same way as a local mind that raised: the engine falls back to
 last_action and the strike will be counted by the DQ layer (#25).
@@ -25,12 +31,17 @@ last_action and the strike will be counted by the DQ layer (#25).
 
 from __future__ import annotations
 
+import hashlib
+import hmac as _hmac
 import json
+import time
 from typing import Any
 
 import httpx
 
 import cells
+
+_HMAC_ALGORITHMS = {"sha256": hashlib.sha256}
 
 
 def _parse_single(d: Any):
@@ -95,6 +106,9 @@ class HttpMind:
         transport: httpx.AsyncBaseTransport | None = None,
         verify: bool = True,
         max_response_bytes: int = 1_048_576,
+        hmac_secret: str | None = None,
+        hmac_algorithm: str = "sha256",
+        hmac_skew_seconds: int = 30,
     ):
         self.name = name
         self._url = url
@@ -102,6 +116,9 @@ class HttpMind:
         self._timeout = timeout
         self._verify = verify
         self._max_response_bytes = max_response_bytes
+        self._hmac_secret = hmac_secret
+        self._hmac_digestmod = _HMAC_ALGORITHMS.get(hmac_algorithm, hashlib.sha256)
+        self._hmac_skew_seconds = hmac_skew_seconds
         client_kwargs = {"timeout": timeout}
         if transport is not None:
             client_kwargs["transport"] = transport
@@ -113,6 +130,12 @@ class HttpMind:
             sys.stderr.write(
                 "warning: HttpMind %r constructed with verify=False; "
                 "TLS certificates will not be checked.\n" % name
+            )
+        if hmac_secret is None:
+            import sys
+            sys.stderr.write(
+                "warning: HttpMind %r constructed without hmac_secret; "
+                "requests will be unsigned and responses unverified.\n" % name
             )
 
         outer = self
@@ -126,16 +149,45 @@ class HttpMind:
 
         self.AgentMind = _AgentMind
 
+    def _sign(self, ts: str, body_bytes: bytes) -> str:
+        message = ts.encode() + b"." + body_bytes
+        return _hmac.new(
+            self._hmac_secret.encode(), message, self._hmac_digestmod
+        ).hexdigest()
+
+    def _verify_response(self, headers, body_bytes: bytes) -> bool:
+        ts_str = headers.get("X-Cells-Timestamp")
+        sig = headers.get("X-Cells-Signature")
+        if not ts_str or not sig:
+            return False
+        try:
+            ts = int(ts_str)
+        except ValueError:
+            return False
+        if abs(ts - int(time.time())) > self._hmac_skew_seconds:
+            return False
+        expected = self._sign(ts_str, body_bytes)
+        return _hmac.compare_digest(expected, sig)
+
     async def _post_capped(self, payload):
         """POST `payload` to the bot's URL, return the parsed JSON, or None
         on error or if the response exceeds `max_response_bytes` (#43).
 
+        When hmac_secret is set, signs the request body and verifies the
+        response signature; mismatched or stale signatures return None (#44).
+
         The body is streamed and the cap is checked after every chunk so a
         gigabyte response can't OOM the engine before the JSON decoder
         notices."""
+        body_bytes = json.dumps(payload).encode()
+        request_headers = {"Content-Type": "application/json", **self._headers}
+        if self._hmac_secret is not None:
+            ts = str(int(time.time()))
+            request_headers["X-Cells-Timestamp"] = ts
+            request_headers["X-Cells-Signature"] = self._sign(ts, body_bytes)
         try:
             async with self._client.stream(
-                "POST", self._url, json=payload, headers=self._headers
+                "POST", self._url, content=body_bytes, headers=request_headers
             ) as r:
                 r.raise_for_status()
                 body = bytearray()
@@ -143,7 +195,11 @@ class HttpMind:
                     body.extend(chunk)
                     if len(body) > self._max_response_bytes:
                         return None
-                return json.loads(bytes(body))
+                resp_bytes = bytes(body)
+                if self._hmac_secret is not None:
+                    if not self._verify_response(r.headers, resp_bytes):
+                        return None
+                return json.loads(resp_bytes)
         except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return None
 


### PR DESCRIPTION
Closes #44

## Summary

- `transports/http_mind.py`: When `hmac_secret` is set, signs every outbound request with `X-Cells-Timestamp` + `X-Cells-Signature` headers (HMAC-SHA256 over `"<ts>.<body_bytes>"`). Verifies the same headers on responses; rejects if missing, wrong signature, or timestamp is outside the skew window (configurable `hmac_skew_seconds`, default 30 s). Without `hmac_secret`, operates unsigned and warns at construction.
- `config.py`: `_load_http` threads `hmac_secret`, `hmac_algorithm`, and `hmac_skew_seconds` through to `HttpMind`.
- `bots.example.toml`: Documents new fields with an inline Python snippet showing the contestant side's verify+sign pattern.

## Test plan

- [x] `test_hmac_no_secret_warns` — construction without `hmac_secret` emits "unsigned" warning to stderr
- [x] `test_hmac_with_secret_no_unsigned_warn` — with `hmac_secret` set, no "unsigned" warning
- [x] `test_hmac_signed_response_accepted` — engine signs request; handler verifies it; handler signs response; engine decodes action
- [x] `test_hmac_mismatched_response_secret_returns_none` — bot signs with wrong key → `None` → strike
- [x] `test_hmac_stale_response_timestamp_returns_none` — response timestamp 60 s old → rejected → `None`
- [x] `test_hmac_missing_response_headers_returns_none` — no signature headers → `None`
- [x] `test_hmac_batch_signed_round_trip` — `act_batch` signs request, verifies signed response
- [x] `test_hmac_batch_bad_response_signature_returns_empty` — mismatched batch response → `{}`
- [x] All 121 existing tests still pass

https://claude.ai/code/session_01MPT9BXEvmXBemLZWE3mz67

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPT9BXEvmXBemLZWE3mz67)_