### PR TITLE
MCP stdio: resource caps (memory / CPU / walltime) (#45)

### DIFF
--- a/bots.example.toml
+++ b/bots.example.toml
@@ -50,10 +50,17 @@ max_response_bytes = 1048576
 
 # MCP mind via stdio: cells spawns the contestant's server as a
 # subprocess and calls the `act` (or `act_batch`) tool over stdio.
+#
+# Optional `limits` inline table caps subprocess resource usage (#45).
+# All three keys are optional; omit the whole table to disable enforcement.
+# memory_mb and cpu_seconds use resource.setrlimit (POSIX only; ignored
+# on Windows). walltime_seconds is enforced by an asyncio task that
+# closes the session when the subprocess overruns its wall-clock budget.
 [bots.carol]
 transport = "mcp"
 mode = "stdio"
 command = ["python", "bots/carol_server.py"]
+limits = { memory_mb = 256, cpu_seconds = 60, walltime_seconds = 600 }
 
 # MCP mind via SSE: cells connects to a hosted MCP endpoint.
 [bots.dave]

--- a/config.py
+++ b/config.py
@@ -52,7 +52,11 @@ def _load_mcp(name, spec):
         command = spec.get("command")
         if not command:
             raise ValueError("bot %r (mcp/stdio) requires 'command'" % name)
-        return McpMind(name, server_command=list(command))
+        return McpMind(
+            name,
+            server_command=list(command),
+            limits=spec.get("limits", {}),
+        )
     if mode == "sse":
         url = spec.get("url")
         if not url:

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -290,6 +290,45 @@ def test_select_bots_unknown_name_raises(tmp_path):
         select_bots(mind_list, ["alice", "ghost"])
 
 
+def test_mcp_stdio_limits_propagate(tmp_path):
+    path = _write(tmp_path, """
+        [bots.carol]
+        transport = "mcp"
+        mode = "stdio"
+        command = ["python", "bots/carol_server.py"]
+        limits = { memory_mb = 256, cpu_seconds = 60, walltime_seconds = 600 }
+    """)
+    mind_list, _ = load_bots(path)
+    _, mind = mind_list[0]
+    assert isinstance(mind, McpMind)
+    assert mind._limits == {"memory_mb": 256, "cpu_seconds": 60, "walltime_seconds": 600}
+
+
+def test_mcp_stdio_no_limits_defaults_to_empty(tmp_path):
+    path = _write(tmp_path, """
+        [bots.carol]
+        transport = "mcp"
+        mode = "stdio"
+        command = ["python", "bots/carol_server.py"]
+    """)
+    mind_list, _ = load_bots(path)
+    _, mind = mind_list[0]
+    assert mind._limits == {}
+
+
+def test_mcp_stdio_partial_limits_propagate(tmp_path):
+    path = _write(tmp_path, """
+        [bots.carol]
+        transport = "mcp"
+        mode = "stdio"
+        command = ["python", "bots/carol_server.py"]
+        limits = { walltime_seconds = 300 }
+    """)
+    mind_list, _ = load_bots(path)
+    _, mind = mind_list[0]
+    assert mind._limits == {"walltime_seconds": 300}
+
+
 # ---------------------------------------------------------------------------
 # CLI integration via subprocess.
 

--- a/tests/test_mcp_mind.py
+++ b/tests/test_mcp_mind.py
@@ -9,13 +9,15 @@ import os
 
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
+import asyncio
 import json
+import sys
 
 import pytest
 from mcp.types import CallToolResult, TextContent
 
 import cells
-from transports.mcp_mind import McpMind
+from transports.mcp_mind import McpMind, _apply_limits_to_command
 
 
 class FakeSession:
@@ -202,3 +204,116 @@ def test_constructor_requires_one_transport():
             server_command=["python", "x.py"],
             server_url="http://example/sse",
         )
+
+
+# ---------------------------------------------------------------------------
+# Resource caps (#45)
+
+
+def test_apply_limits_no_limits_returns_command_unchanged():
+    cmd = ["python", "bot.py", "--arg"]
+    assert _apply_limits_to_command(cmd, {}) == cmd
+    assert _apply_limits_to_command(cmd, {"walltime_seconds": 600}) == cmd
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_apply_limits_memory_wraps_command():
+    cmd = ["python", "bot.py", "--arg"]
+    result = _apply_limits_to_command(cmd, {"memory_mb": 256})
+    assert result[0] == sys.executable
+    assert result[1] == "-c"
+    assert "RLIMIT_AS" in result[2]
+    assert str(256 * 1024 * 1024) in result[2]
+    assert result[3:] == cmd
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_apply_limits_cpu_wraps_command():
+    cmd = ["python", "bot.py"]
+    result = _apply_limits_to_command(cmd, {"cpu_seconds": 60})
+    assert result[0] == sys.executable
+    assert result[1] == "-c"
+    assert "RLIMIT_CPU" in result[2]
+    assert "60" in result[2]
+    assert result[3:] == cmd
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_apply_limits_both_caps_include_both_rlimits():
+    result = _apply_limits_to_command(
+        ["python", "bot.py"], {"memory_mb": 128, "cpu_seconds": 30}
+    )
+    assert "RLIMIT_AS" in result[2]
+    assert "RLIMIT_CPU" in result[2]
+    assert str(128 * 1024 * 1024) in result[2]
+    assert "30" in result[2]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_apply_limits_wrapper_ends_with_execvp():
+    result = _apply_limits_to_command(["python", "bot.py"], {"cpu_seconds": 5})
+    assert "execvp" in result[2]
+
+
+async def test_no_limits_no_walltime_task():
+    """When no limits are configured, no walltime task is created."""
+    session = FakeSession(structured={"type": cells.ACT_EAT})
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    await agent.act(_make_view(), [])
+    assert mind._walltime_task is None
+
+
+async def test_walltime_task_started_on_first_act():
+    """A walltime task is created on the first act() call."""
+    session = FakeSession(structured={"type": cells.ACT_EAT})
+    mind = McpMind("bot", session=session, limits={"walltime_seconds": 60.0})
+    agent = mind.AgentMind(None)
+    assert mind._walltime_task is None
+    await agent.act(_make_view(), [])
+    assert mind._walltime_task is not None
+    assert not mind._walltime_task.done()
+    # Clean up so the task doesn't outlive the test.
+    await mind.aclose()
+    await asyncio.sleep(0)
+
+
+async def test_walltime_closes_session_after_expiry():
+    """After walltime_seconds elapses, the session is torn down and
+    subsequent act() calls return None (counted as strikes by the DQ layer)."""
+    session = FakeSession(structured={"type": cells.ACT_EAT})
+    mind = McpMind("bot", session=session, limits={"walltime_seconds": 0.05})
+    agent = mind.AgentMind(None)
+
+    result = await agent.act(_make_view(), [])
+    assert result is not None
+
+    await asyncio.sleep(0.15)
+
+    result = await agent.act(_make_view(), [])
+    assert result is None
+
+
+async def test_aclose_cancels_pending_walltime_task():
+    """Calling aclose() before walltime fires cancels the pending task."""
+    session = FakeSession(structured={"type": cells.ACT_EAT})
+    mind = McpMind("bot", session=session, limits={"walltime_seconds": 60.0})
+    agent = mind.AgentMind(None)
+
+    await agent.act(_make_view(), [])
+    task = mind._walltime_task
+    assert task is not None
+
+    await mind.aclose()
+    assert mind._walltime_task is None
+
+    await asyncio.sleep(0)
+    assert task.cancelled()
+
+
+async def test_walltime_only_config_does_not_wrap_command():
+    """walltime_seconds alone must not alter the server command — it only
+    affects the asyncio side, not the subprocess invocation."""
+    cmd = ["python", "bot.py"]
+    result = _apply_limits_to_command(cmd, {"walltime_seconds": 600})
+    assert result == cmd

--- a/tests/test_mcp_mind.py
+++ b/tests/test_mcp_mind.py
@@ -234,7 +234,7 @@ def test_apply_limits_cpu_wraps_command():
     assert result[0] == sys.executable
     assert result[1] == "-c"
     assert "RLIMIT_CPU" in result[2]
-    assert "60" in result[2]
+    assert "(60,60)" in result[2]
     assert result[3:] == cmd
 
 
@@ -246,13 +246,25 @@ def test_apply_limits_both_caps_include_both_rlimits():
     assert "RLIMIT_AS" in result[2]
     assert "RLIMIT_CPU" in result[2]
     assert str(128 * 1024 * 1024) in result[2]
-    assert "30" in result[2]
+    assert "(30,30)" in result[2]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
 def test_apply_limits_wrapper_ends_with_execvp():
     result = _apply_limits_to_command(["python", "bot.py"], {"cpu_seconds": 5})
     assert "execvp" in result[2]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_apply_limits_float_values_cast_to_int():
+    """Float TOML values (e.g. cpu_seconds = 60.9) must not produce a
+    TypeError inside the subprocess wrapper."""
+    result = _apply_limits_to_command(
+        ["python", "bot.py"], {"memory_mb": 256.0, "cpu_seconds": 60.9}
+    )
+    # Both limits must appear as plain integers in the one-liner.
+    assert "(268435456,268435456)" in result[2]
+    assert "(60,60)" in result[2]
 
 
 async def test_no_limits_no_walltime_task():

--- a/transports/mcp_mind.py
+++ b/transports/mcp_mind.py
@@ -17,17 +17,46 @@ Two transports are supported:
 Errors (connection drop, malformed payload, server-reported error) are
 swallowed: act() returns None and the engine falls back to last_action.
 The DQ layer (#25) is responsible for counting strikes.
+
+Resource limits (#45): stdio minds accept a `limits` dict with optional
+keys memory_mb, cpu_seconds, and walltime_seconds. On POSIX, memory and
+CPU caps are applied via a thin wrapper that calls resource.setrlimit
+before exec-ing the real server. Walltime is enforced by an asyncio task
+that tears down the session when it expires. All limits are no-ops on
+Windows.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+import sys
 from contextlib import AsyncExitStack
 from typing import Any
 
 from transports.http_mind import _parse_action, _parse_batch_response
 
 import cells
+
+
+def _apply_limits_to_command(command: list[str], limits: dict) -> list[str]:
+    """On POSIX, prepend a Python one-liner that sets RLIMIT_AS / RLIMIT_CPU
+    before exec-ing the real server command. Returns command unchanged on
+    Windows or when neither cap is requested."""
+    memory_mb = limits.get("memory_mb")
+    cpu_seconds = limits.get("cpu_seconds")
+    if sys.platform == "win32" or (memory_mb is None and cpu_seconds is None):
+        return command
+    stmts = ["import resource,os,sys"]
+    if memory_mb is not None:
+        b = memory_mb * 1024 * 1024
+        stmts.append(f"resource.setrlimit(resource.RLIMIT_AS,({b},{b}))")
+    if cpu_seconds is not None:
+        stmts.append(
+            f"resource.setrlimit(resource.RLIMIT_CPU,({cpu_seconds},{cpu_seconds}))"
+        )
+    stmts.append("os.execvp(sys.argv[1],sys.argv[1:])")
+    return [sys.executable, "-c", ";".join(stmts)] + list(command)
 
 
 def _parse_result(result) -> Any:
@@ -82,6 +111,7 @@ class McpMind:
         server_command: list[str] | None = None,
         server_url: str | None = None,
         session=None,
+        limits: dict | None = None,
     ):
         if (server_command is None) == (server_url is None) and session is None:
             raise ValueError(
@@ -92,6 +122,9 @@ class McpMind:
         self._server_url = server_url
         self._session = session
         self._stack: AsyncExitStack | None = None
+        self._limits: dict = limits or {}
+        self._walltime_task: asyncio.Task | None = None
+        self._walltime_started = False
 
         outer = self
 
@@ -105,29 +138,43 @@ class McpMind:
         self.AgentMind = _AgentMind
 
     async def _ensure_session(self):
-        if self._session is not None:
-            return
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        if self._session is None:
+            from mcp import ClientSession
+            from mcp.client.stdio import StdioServerParameters, stdio_client
 
-        self._stack = AsyncExitStack()
-        if self._server_command is not None:
-            params = StdioServerParameters(
-                command=self._server_command[0],
-                args=list(self._server_command[1:]),
+            self._stack = AsyncExitStack()
+            if self._server_command is not None:
+                effective_command = _apply_limits_to_command(
+                    self._server_command, self._limits
+                )
+                params = StdioServerParameters(
+                    command=effective_command[0],
+                    args=list(effective_command[1:]),
+                )
+                read, write = await self._stack.enter_async_context(stdio_client(params))
+            else:
+                from mcp.client.sse import sse_client
+
+                read, write = await self._stack.enter_async_context(
+                    sse_client(self._server_url)
+                )
+
+            self._session = await self._stack.enter_async_context(
+                ClientSession(read, write)
             )
-            read, write = await self._stack.enter_async_context(stdio_client(params))
-        else:
-            from mcp.client.sse import sse_client
+            await self._session.initialize()
 
-            read, write = await self._stack.enter_async_context(
-                sse_client(self._server_url)
-            )
+        if not self._walltime_started:
+            self._walltime_started = True
+            walltime = self._limits.get("walltime_seconds")
+            if walltime is not None:
+                self._walltime_task = asyncio.get_running_loop().create_task(
+                    self._enforce_walltime(walltime)
+                )
 
-        self._session = await self._stack.enter_async_context(
-            ClientSession(read, write)
-        )
-        await self._session.initialize()
+    async def _enforce_walltime(self, seconds: float):
+        await asyncio.sleep(seconds)
+        await self.aclose()
 
     async def _call(self, view, msg):
         try:
@@ -158,6 +205,10 @@ class McpMind:
         return _parse_batch_result(result)
 
     async def aclose(self):
+        task = self._walltime_task
+        self._walltime_task = None
+        if task is not None and not task.done() and asyncio.current_task() is not task:
+            task.cancel()
         if self._stack is not None:
             await self._stack.aclose()
             self._stack = None

--- a/transports/mcp_mind.py
+++ b/transports/mcp_mind.py
@@ -49,12 +49,11 @@ def _apply_limits_to_command(command: list[str], limits: dict) -> list[str]:
         return command
     stmts = ["import resource,os,sys"]
     if memory_mb is not None:
-        b = memory_mb * 1024 * 1024
+        b = int(memory_mb) * 1024 * 1024
         stmts.append(f"resource.setrlimit(resource.RLIMIT_AS,({b},{b}))")
     if cpu_seconds is not None:
-        stmts.append(
-            f"resource.setrlimit(resource.RLIMIT_CPU,({cpu_seconds},{cpu_seconds}))"
-        )
+        s = int(cpu_seconds)
+        stmts.append(f"resource.setrlimit(resource.RLIMIT_CPU,({s},{s}))")
     stmts.append("os.execvp(sys.argv[1],sys.argv[1:])")
     return [sys.executable, "-c", ";".join(stmts)] + list(command)
 


### PR DESCRIPTION
Closes #45.

## Summary

- **`transports/mcp_mind.py`** — `_apply_limits_to_command` wraps the stdio subprocess command with a Python one-liner that calls `resource.setrlimit(RLIMIT_AS)` and/or `resource.setrlimit(RLIMIT_CPU)` before `os.execvp`-ing the real server (POSIX only; returns command unchanged on Windows or when neither cap is set). A `walltime_seconds` asyncio task is started on the first `act()` call and calls `aclose()` when the budget expires; `aclose()` is careful not to cancel itself when called from the walltime task.
- **`config.py`** — `_load_mcp` now reads `spec.get("limits", {})` and threads it into `McpMind(limits=...)` for stdio bots. SSE bots have no subprocess so limits are not forwarded.
- **`bots.example.toml`** — Carol's stdio section gains an example `limits` inline table with all three keys documented.

## Behavior

| Scenario | Result |
|---|---|
| `memory_mb` exceeded | OS delivers SIGKILL to subprocess; next `act()` raises, `_call` swallows → None → strike |
| `cpu_seconds` exceeded | OS delivers SIGXCPU/SIGKILL; same path as above |
| `walltime_seconds` exceeded | asyncio task calls `aclose()`; subsequent `act()` returns None → strike |
| No `limits` section | Zero change to existing behavior |
| Windows | `_apply_limits_to_command` is a no-op; walltime still works |

## Test plan

- [x] `test_apply_limits_no_limits_returns_command_unchanged` — empty dict and walltime-only dict leave command untouched
- [x] `test_apply_limits_memory_wraps_command` — RLIMIT_AS and correct byte value present in wrapper
- [x] `test_apply_limits_cpu_wraps_command` — RLIMIT_CPU and correct seconds present
- [x] `test_apply_limits_both_caps_include_both_rlimits` — both limits in single wrapper
- [x] `test_apply_limits_wrapper_ends_with_execvp` — wrapper actually exec-s the real command
- [x] `test_no_limits_no_walltime_task` — no task created when `limits={}` or omitted
- [x] `test_walltime_task_started_on_first_act` — task exists after first call
- [x] `test_walltime_closes_session_after_expiry` — act() returns None after walltime fires
- [x] `test_aclose_cancels_pending_walltime_task` — external aclose cancels the task cleanly
- [x] `test_walltime_only_config_does_not_wrap_command` — walltime_seconds alone does not alter the subprocess command
- [x] `test_mcp_stdio_limits_propagate` — full limits dict round-trips through `load_bots`
- [x] `test_mcp_stdio_no_limits_defaults_to_empty` — missing limits → `_limits == {}`
- [x] `test_mcp_stdio_partial_limits_propagate` — partial limits dict (walltime only) propagates correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_0174YeCN797ANhU4hm9UMQkA)_