### PR TITLE
Add pyproject.toml so `pip install git+...` works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = [
+    "setuptools>=68",
+    "wheel",
+    # Build-time deps for cells_helpers.pyx (see setup.py).
+    "Cython>=3.0",
+    "numpy>=1.24",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cells"
+version = "0.1.0"
+description = "A multi-agent Python programming game."
+readme = "README"
+requires-python = ">=3.11"
+dependencies = [
+    "numpy>=1.24",
+    "pygame>=2.5",
+    "httpx>=0.27",
+    "mcp>=1.0",
+]
+
+[tool.setuptools]
+# Top-level Python files installed alongside the Cython extension.
+py-modules = ["cells", "tournament", "config"]
+
+[tool.setuptools.packages.find]
+# Include only the in-tree subpackages cells ships; avoid sweeping up tests/.
+include = ["minds*", "terrain*", "transports*"]


### PR DESCRIPTION
Adds a PEP 621 `pyproject.toml` so external consumers can `pip install` cells as a normal Git dep. Filed downstream from `SparrowG/cells-server#21` — that issue tracks dropping a documented two-step workaround in cells-server once this lands.

## What was broken

Cells's existing `setup.py` only configures the Cython extension build:

```python
setup(
    ext_modules=cythonize([Extension("cells_helpers", ...)])
)
```

No `name`, no `version`, no `py_modules`, no `packages`, no `install_requires`, and there's no `pyproject.toml` declaring a build-system. The result:

```
$ pip install "cells @ git+https://github.com/SparrowG/cells.git@<sha>"
WARNING: Generating metadata for package cells produced metadata for project name unknown.
ERROR: Could not find a version that satisfies the requirement cells (unavailable)
```

…because pip can't reconcile the requested name (`cells`) with the metadata setuptools produced (no name).

CI hasn't noticed because the workflow installs `requirements-dev.txt` (which sources `requirements.txt`), not the package itself.

## What this PR does

Adds a single `pyproject.toml` with:

- `[build-system].requires`: `setuptools>=68`, `wheel`, `Cython>=3.0`, `numpy>=1.24`. The last two are build-time deps the existing `setup.py` imports unconditionally — without them in build-system requires, an isolated build env fails on `import numpy` / `from Cython.Build import cythonize`.
- `[project]` metadata: `name = "cells"`, `version = "0.1.0"`, description, readme, `requires-python >=3.11`. Runtime `dependencies` mirror `requirements.txt` exactly: `numpy>=1.24`, `pygame>=2.5`, `httpx>=0.27`, `mcp>=1.0`.
- `[tool.setuptools] py-modules`: `cells`, `tournament`, `config` (the top-level Python files).
- `[tool.setuptools.packages.find].include`: `minds*`, `terrain*`, `transports*` (sweeps the in-tree subpackages without picking up `tests/`).

`setup.py` is unchanged. Setuptools merges metadata from `pyproject.toml` with `ext_modules` from `setup.py`.

## Verification

In a clean Python 3.11 venv:

```
$ pip install "cells @ git+https://github.com/SparrowG/cells.git@<this-pr's-sha>"
Successfully built cells
Successfully installed cells-0.1.0 ...

$ SDL_VIDEODRIVER=dummy python -c "import cells; print(cells.Game, cells.ACT_EAT)"
<class 'cells.Game'> 2
```

Local headless game smoke (mind1 vs mind2 with seed=42, max_time=200) produces a 1-1 draw at 202 ticks.

## Tests

`SDL_VIDEODRIVER=dummy pytest tests/` against the same checkout: **137 passed, 1 warning** in 9.94s.

I ran tests after building the Cython extension in-place (`python setup.py build_ext --inplace`), which is what `pytest.ini` expects in the source tree. Existing tests didn't need any changes.

## Notes for review

- **Version `0.1.0`**: arbitrary first-shipped value. If you'd rather pin to `0.0.0` or a date-based scheme, easy change. There's no public release tag yet, and `cells.__version__` isn't exposed (could be a follow-up — `cells_server.runner` reads `importlib.metadata.version("cells")` to stamp matches with the engine version).
- **Why list runtime deps in pyproject AND keep `requirements.txt`**: the requirements files are what CI installs today (`pip install -r requirements-dev.txt`). I left them alone to keep this PR scope-pure to "external installs work." A future PR could collapse `requirements.txt` to `pip install -e .` and `requirements-dev.txt` to `pip install -e ".[dev]"` (with a `[project.optional-dependencies] dev` table). Out of scope here.
- **`packages.find` `include` list** is explicit (vs. `find_namespace_packages()`) so adding a new top-level dir doesn't accidentally get installed.
- **No CI change**: the existing workflow uses `pip install -r requirements-dev.txt` and that still works. Adding a "pip install ." smoke test step would be a nice belt-and-braces; happy to add if you want.

## Test plan

- [x] `pip install "cells @ git+https://github.com/SparrowG/cells.git@<sha>"` succeeds in a clean venv.
- [x] `import cells; cells.Game; cells.ACT_EAT` resolves correctly.
- [x] mind1 vs mind2 headless game runs to completion.
- [x] `pytest tests/` → 137 passed.
- [ ] Verify on Python 3.12 in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx3ixzjeCC6io8c8h45MQP)_