### PR TITLE
fix: HTTP/MCP transports crash on every act()/act_batch() call (#53)

### DIFF
--- a/tests/test_http_mind.py
+++ b/tests/test_http_mind.py
@@ -67,6 +67,55 @@ def _make_view():
     return cells.WorldView(me, [], [], terr, energy, tick=1)
 
 
+def _msgs(*items):
+    """A real cells.MessageQueue, as the engine always passes to
+    act()/act_batch() — never a plain list (#53)."""
+    q = cells.MessageQueue()
+    for item in items:
+        q.send_message(item)
+    q.update()
+    return q
+
+
+async def test_act_serializes_real_message_queue():
+    """The engine always calls act()/act_batch() with a live
+    cells.MessageQueue (#53), not a plain list — list(msg) isn't
+    iterable and raised TypeError before every request could be sent."""
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"type": 2})
+
+    queue = cells.MessageQueue()
+    queue.send_message("hello")
+    queue.update()
+
+    mind = _make_mind(handler)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), queue)
+    assert isinstance(action, cells.Action)
+    assert captured["body"]["messages"] == ["hello"]
+    await mind.aclose()
+
+
+async def test_act_batch_serializes_real_message_queue():
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"actions": []})
+
+    queue = cells.MessageQueue()
+    queue.send_message("gg")
+    queue.update()
+
+    mind = _make_mind(handler)
+    await mind.act_batch([("agent-0", _make_view())], queue)
+    assert captured["body"]["messages"] == ["gg"]
+    await mind.aclose()
+
+
 async def test_single_action_response():
     captured = {}
 
@@ -76,7 +125,7 @@ async def test_single_action_response():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    action = await agent.act(_make_view(), [])
+    action = await agent.act(_make_view(), _msgs())
     assert isinstance(action, cells.Action)
     assert action.type == cells.ACT_EAT
     # Verify the request body has the snapshot schema.
@@ -92,7 +141,7 @@ async def test_action_with_data_field():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    action = await agent.act(_make_view(), [])
+    action = await agent.act(_make_view(), _msgs())
     assert action.type == cells.ACT_MOVE
     assert action.get_data() == [3, 4]
     await mind.aclose()
@@ -112,7 +161,7 @@ async def test_pre_planned_moves_response():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    actions = await agent.act(_make_view(), [])
+    actions = await agent.act(_make_view(), _msgs())
     assert isinstance(actions, list)
     assert len(actions) == 2
     assert actions[0].type == cells.ACT_MOVE
@@ -128,7 +177,7 @@ async def test_malformed_response_returns_none():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -139,7 +188,7 @@ async def test_5xx_response_returns_none():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -150,7 +199,7 @@ async def test_response_missing_type_returns_none():
 
     mind = _make_mind(handler)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -175,7 +224,7 @@ async def test_act_batch_round_trip():
     mind = _make_mind(handler)
     v0 = _make_view()
     v1 = _make_view()
-    out = await mind.act_batch([("agent-0", v0), ("agent-1", v1)], ["hello"])
+    out = await mind.act_batch([("agent-0", v0), ("agent-1", v1)], _msgs("hello"))
 
     body = captured["body"]
     assert body["tick"] == 1
@@ -195,7 +244,7 @@ async def test_act_batch_http_error_returns_empty():
         return httpx.Response(500, text="upstream error")
 
     mind = _make_mind(handler)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out == {}
     await mind.aclose()
 
@@ -211,7 +260,7 @@ async def test_act_batch_partial_response():
 
     mind = _make_mind(handler)
     out = await mind.act_batch(
-        [("agent-0", _make_view()), ("agent-1", _make_view())], []
+        [("agent-0", _make_view()), ("agent-1", _make_view())], _msgs()
     )
     assert "agent-0" not in out
     assert out["agent-1"].type == cells.ACT_LIFT
@@ -234,7 +283,7 @@ async def test_oversized_response_returns_none():
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -249,7 +298,7 @@ async def test_response_just_under_cap_decoded_normally():
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000_000)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert isinstance(result, cells.Action)
     assert result.type == cells.ACT_EAT
     await mind.aclose()
@@ -268,7 +317,7 @@ async def test_oversized_batch_response_returns_empty_dict():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, max_response_bytes=1_000)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out == {}
     await mind.aclose()
 
@@ -285,7 +334,7 @@ async def test_default_cap_handles_realistic_batch_response():
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport)
     out = await mind.act_batch(
-        [(f"agent-{i}", _make_view()) for i in range(50)], []
+        [(f"agent-{i}", _make_view()) for i in range(50)], _msgs()
     )
     assert len(out) == 50
     assert all(a.type == cells.ACT_EAT for a in out.values())
@@ -377,7 +426,7 @@ async def test_hmac_signed_response_accepted():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret=SECRET)
-    action = await mind.AgentMind(None).act(_make_view(), [])
+    action = await mind.AgentMind(None).act(_make_view(), _msgs())
     assert isinstance(action, cells.Action)
     assert action.type == cells.ACT_EAT
     assert req_captured["ts"] is not None
@@ -394,7 +443,7 @@ async def test_hmac_mismatched_response_secret_returns_none():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="correct-secret")
-    result = await mind.AgentMind(None).act(_make_view(), [])
+    result = await mind.AgentMind(None).act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -408,7 +457,7 @@ async def test_hmac_stale_response_timestamp_returns_none():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="s3cr3t")
-    result = await mind.AgentMind(None).act(_make_view(), [])
+    result = await mind.AgentMind(None).act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -420,7 +469,7 @@ async def test_hmac_missing_response_headers_returns_none():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="s3cr3t")
-    result = await mind.AgentMind(None).act(_make_view(), [])
+    result = await mind.AgentMind(None).act(_make_view(), _msgs())
     assert result is None
     await mind.aclose()
 
@@ -437,7 +486,7 @@ async def test_hmac_batch_signed_round_trip():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret=SECRET)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out["agent-0"].type == cells.ACT_EAT
     await mind.aclose()
 
@@ -453,6 +502,6 @@ async def test_hmac_batch_bad_response_signature_returns_empty():
 
     transport = httpx.MockTransport(handler)
     mind = HttpMind("bot", "http://test.invalid/act", transport=transport, hmac_secret="correct-secret")
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out == {}
     await mind.aclose()

--- a/tests/test_in_process_server.py
+++ b/tests/test_in_process_server.py
@@ -168,7 +168,9 @@ async def test_subprocess_server_returns_action():
     )
     agent = mind.AgentMind(None)
     view = _make_view()
-    result = await agent.act(view, [])
+    # The engine always calls act()/act_batch() with a live
+    # cells.MessageQueue, never a plain list (#53).
+    result = await agent.act(view, cells.MessageQueue())
     await mind.aclose()
     assert result is not None
     assert hasattr(result, "type")
@@ -184,7 +186,7 @@ async def test_subprocess_server_act_batch():
     view1 = _make_view(x=3, y=3)
     view2 = _make_view(x=7, y=7)
     out = await mind.act_batch(
-        [("agent-1", view1), ("agent-2", view2)], []
+        [("agent-1", view1), ("agent-2", view2)], cells.MessageQueue()
     )
     await mind.aclose()
     assert "agent-1" in out

--- a/tests/test_mcp_mind.py
+++ b/tests/test_mcp_mind.py
@@ -59,11 +59,49 @@ def _make_view():
     return cells.WorldView(_StubAgent(), [], [], terr, energy, tick=1)
 
 
+def _msgs(*items):
+    """A real cells.MessageQueue, as the engine always passes to
+    act()/act_batch() — never a plain list (#53)."""
+    q = cells.MessageQueue()
+    for item in items:
+        q.send_message(item)
+    q.update()
+    return q
+
+
+async def test_act_serializes_real_message_queue():
+    """The engine always calls act()/act_batch() with a live
+    cells.MessageQueue (#53), not a plain list — list(msg) isn't
+    iterable and raised TypeError (silently swallowed by _call's
+    bare except, returning None) before every request could be sent."""
+    queue = cells.MessageQueue()
+    queue.send_message("hello")
+    queue.update()
+
+    session = FakeSession(structured={"type": 2})
+    mind = McpMind("bot", session=session)
+    agent = mind.AgentMind(None)
+    action = await agent.act(_make_view(), queue)
+    assert action.type == cells.ACT_EAT
+    assert session.calls[0][1]["messages"] == ["hello"]
+
+
+async def test_act_batch_serializes_real_message_queue():
+    queue = cells.MessageQueue()
+    queue.send_message("gg")
+    queue.update()
+
+    session = FakeSession(structured={"actions": []})
+    mind = McpMind("bot", session=session)
+    await mind.act_batch([("agent-0", _make_view())], queue)
+    assert session.calls[0][1]["messages"] == ["gg"]
+
+
 async def test_structured_content_action():
     session = FakeSession(structured={"type": 2})
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    action = await agent.act(_make_view(), [])
+    action = await agent.act(_make_view(), _msgs())
     assert action.type == cells.ACT_EAT
     # Verify the call_tool args carry the snapshot.
     assert session.calls[0][0] == "act"
@@ -75,7 +113,7 @@ async def test_text_content_action():
     session = FakeSession(text=json.dumps({"type": 1, "data": [3, 4]}))
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    action = await agent.act(_make_view(), [])
+    action = await agent.act(_make_view(), _msgs())
     assert action.type == cells.ACT_MOVE
     assert action.get_data() == [3, 4]
 
@@ -91,7 +129,7 @@ async def test_pre_planned_moves_via_structured():
     )
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    actions = await agent.act(_make_view(), [])
+    actions = await agent.act(_make_view(), _msgs())
     assert len(actions) == 2
     assert actions[0].type == cells.ACT_MOVE
     assert actions[1].type == cells.ACT_EAT
@@ -101,7 +139,7 @@ async def test_is_error_returns_none():
     session = FakeSession(structured={"type": 2}, is_error=True)
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
 
 
@@ -109,7 +147,7 @@ async def test_call_tool_raises_returns_none():
     session = FakeSession(raises=RuntimeError("connection dropped"))
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
 
 
@@ -117,7 +155,7 @@ async def test_text_content_malformed_returns_none():
     session = FakeSession(text="not json at all")
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
 
 
@@ -134,7 +172,7 @@ async def test_act_batch_round_trip():
     )
     mind = McpMind("bot", session=session)
     out = await mind.act_batch(
-        [("agent-0", _make_view()), ("agent-1", _make_view())], ["hello"]
+        [("agent-0", _make_view()), ("agent-1", _make_view())], _msgs("hello")
     )
     assert session.calls[0][0] == "act_batch"
     args = session.calls[0][1]
@@ -150,21 +188,21 @@ async def test_act_batch_text_content():
     payload = {"actions": [{"id": "agent-0", "action": {"type": cells.ACT_EAT}}]}
     session = FakeSession(text=json.dumps(payload))
     mind = McpMind("bot", session=session)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out["agent-0"].type == cells.ACT_EAT
 
 
 async def test_act_batch_call_raises_returns_empty():
     session = FakeSession(raises=RuntimeError("boom"))
     mind = McpMind("bot", session=session)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out == {}
 
 
 async def test_act_batch_is_error_returns_empty():
     session = FakeSession(structured={"actions": []}, is_error=True)
     mind = McpMind("bot", session=session)
-    out = await mind.act_batch([("agent-0", _make_view())], [])
+    out = await mind.act_batch([("agent-0", _make_view())], _msgs())
     assert out == {}
 
 
@@ -272,7 +310,7 @@ async def test_no_limits_no_walltime_task():
     session = FakeSession(structured={"type": cells.ACT_EAT})
     mind = McpMind("bot", session=session)
     agent = mind.AgentMind(None)
-    await agent.act(_make_view(), [])
+    await agent.act(_make_view(), _msgs())
     assert mind._walltime_task is None
 
 
@@ -282,7 +320,7 @@ async def test_walltime_task_started_on_first_act():
     mind = McpMind("bot", session=session, limits={"walltime_seconds": 60.0})
     agent = mind.AgentMind(None)
     assert mind._walltime_task is None
-    await agent.act(_make_view(), [])
+    await agent.act(_make_view(), _msgs())
     assert mind._walltime_task is not None
     assert not mind._walltime_task.done()
     # Clean up so the task doesn't outlive the test.
@@ -297,12 +335,12 @@ async def test_walltime_closes_session_after_expiry():
     mind = McpMind("bot", session=session, limits={"walltime_seconds": 0.05})
     agent = mind.AgentMind(None)
 
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is not None
 
     await asyncio.sleep(0.15)
 
-    result = await agent.act(_make_view(), [])
+    result = await agent.act(_make_view(), _msgs())
     assert result is None
 
 
@@ -312,7 +350,7 @@ async def test_aclose_cancels_pending_walltime_task():
     mind = McpMind("bot", session=session, limits={"walltime_seconds": 60.0})
     agent = mind.AgentMind(None)
 
-    await agent.act(_make_view(), [])
+    await agent.act(_make_view(), _msgs())
     task = mind._walltime_task
     assert task is not None
 

--- a/transports/http_mind.py
+++ b/transports/http_mind.py
@@ -206,7 +206,7 @@ class HttpMind:
     async def _call(self, view, msg):
         payload = {
             "view": view.to_json(),
-            "messages": list(msg),
+            "messages": msg.get_messages(),
         }
         return _parse_action(await self._post_capped(payload))
 
@@ -217,7 +217,7 @@ class HttpMind:
             return {}
         payload = {
             "tick": int(agents[0][1].tick),
-            "messages": list(msg),
+            "messages": msg.get_messages(),
             "agents": [{"id": aid, "view": v.to_json()} for (aid, v) in agents],
         }
         raw = await self._post_capped(payload)

--- a/transports/mcp_mind.py
+++ b/transports/mcp_mind.py
@@ -180,7 +180,7 @@ class McpMind:
             await self._ensure_session()
             result = await self._session.call_tool(
                 "act",
-                arguments={"view": view.to_json(), "messages": list(msg)},
+                arguments={"view": view.to_json(), "messages": msg.get_messages()},
             )
             return _parse_result(result)
         except Exception:
@@ -193,7 +193,7 @@ class McpMind:
             return {}
         arguments = {
             "tick": int(agents[0][1].tick),
-            "messages": list(msg),
+            "messages": msg.get_messages(),
             "agents": [{"id": aid, "view": v.to_json()} for (aid, v) in agents],
         }
         try:


### PR DESCRIPTION
Closes #53.

## Problem

`HttpMind`/`McpMind`'s `_call`/`act_batch` (`transports/http_mind.py:209,220`, `transports/mcp_mind.py:183,196`) build the wire payload with:

```python
"messages": list(msg),
```

`msg` is always `self.messages[team]` (`cells.py:313,337`) — a live `cells.MessageQueue`, which exposes only `send_message()` / `get_messages()` / `update()`, no `__iter__`/`__getitem__`. `list(msg)` raises `TypeError` on **every** `act()`/`act_batch()` call — for every HTTP bot, every MCP bot, and every `sandbox="subprocess"` in-process bot (dispatched through `McpMind`).

`Game._dispatch_team` routes any mind exposing `act_batch` through `_dispatch_team_batch`, which swallows the exception (`except Exception: reason = "exception"`) and records a strike. With the default `strike_threshold=3`, **every HTTP/MCP/subprocess-sandboxed team is disqualified after exactly 3 ticks**, before the bot ever gets a real chance to respond.

Verified live (see PR checks below): before the fix, an `HttpMind`-backed team accumulates strikes and is disqualified within a few ticks with reason `exception`/`malformed`; existing unit tests never caught this because they call `act()`/`act_batch()` with a bare `[]` (iterable, so `list(msg)` silently "worked" on the wrong input) instead of a real `MessageQueue`.

## Fix

Serialize via `msg.get_messages()` (already a list) at all four call sites instead of `list(msg)`.

## Test plan

- [x] Updated `tests/test_http_mind.py`, `tests/test_mcp_mind.py`, `tests/test_in_process_server.py` to construct a real `cells.MessageQueue` (via a new `_msgs()` helper) everywhere a bare `[]` previously stood in for "no messages" — the old substitution is exactly what let this bug go unnoticed.
- [x] Added `test_act_serializes_real_message_queue` / `test_act_batch_serializes_real_message_queue` to both `test_http_mind.py` and `test_mcp_mind.py`, asserting the wire payload's `messages` field matches a populated `MessageQueue`'s `get_messages()`. These fail with `AttributeError`/`TypeError` against the pre-fix code.
- [x] `SDL_VIDEODRIVER=dummy pytest -q` — 162 passed.
- [x] Live end-to-end repro: ran a real `cells.Game` with an `HttpMind`-backed team for 6 ticks against a mock bot server. Before the fix: DQ'd within 3 ticks (`strike_log` shows `malformed`/`exception`). After the fix: `strikes=[0, 0]`, `disqualified=set()`, all 6 requests succeeded with the correct `messages` field serialized.

---
_Generated by [Claude Code](https://claude.ai/code/session_018VUj7VyFxyzDTpU2Dpqka9)_